### PR TITLE
Add token refresh and dynamic orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # ha-wait-for-wolt
+
+This custom component tracks your Wolt orders in Home Assistant. It polls the Wolt API using tokens that you obtain once from the web site and keeps them refreshed automatically.
+
+## Installation via HACS
+1. Add this repository as a custom repository in [HACS](https://hacs.xyz/).
+2. Install **Wolt Order Tracker** and restart Home Assistant.
+
+## Getting your tokens
+1. Log in to [wolt.com](https://wolt.com) in a browser.
+2. Inspect the network requests or local storage and copy the values of `w-wolt-session-id`, `access_token` and `refresh_token`.
+3. Use these values in the configuration below. The integration will refresh the access token when needed using the refresh token.
+
+## Configuration
+Add a sensor entry to `configuration.yaml`:
+
+```yaml
+sensor:
+  - platform: wait_for_wolt
+    name: My Wolt Account
+    session_id: YOUR_SESSION_ID
+    bearer_token: YOUR_ACCESS_TOKEN
+    refresh_token: YOUR_REFRESH_TOKEN
+```
+
+## How it works
+- The integration refreshes the bearer token automatically.
+- Every minute it polls Wolt for your active orders.
+- A sensor entity is created for each order that is in progress. The sensor state reflects the current order status and attributes include the delivery estimate, venue and items ordered.
+- New orders placed while Home Assistant is running are discovered automatically within the polling interval.
+
+## Limitations
+- The integration relies on tokens taken from the Wolt web site. If they become invalid you will need to capture new ones.

--- a/custom_components/wait_for_wolt/__init__.py
+++ b/custom_components/wait_for_wolt/__init__.py
@@ -1,0 +1,170 @@
+"""Wolt order tracker integration."""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from typing import Any, Dict, List
+
+import aiohttp
+import async_timeout
+import voluptuous as vol
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+import homeassistant.helpers.config_validation as cv
+
+from .const import (
+    DOMAIN,
+    CONF_SESSION_ID,
+    CONF_BEARER_TOKEN,
+    CONF_REFRESH_TOKEN,
+    DEFAULT_NAME,
+    UPDATE_INTERVAL,
+    HEADERS,
+    REFRESH_URL,
+    ACTIVE_ORDERS_URL,
+    ORDER_DETAILS_URL,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_SESSION_ID): cv.string,
+        vol.Required(CONF_BEARER_TOKEN): cv.string,
+        vol.Required(CONF_REFRESH_TOKEN): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    }
+)
+
+
+class WoltApi:
+    """Simple wrapper for the Wolt API."""
+
+    def __init__(self, session: aiohttp.ClientSession, session_id: str, token: str, refresh: str) -> None:
+        self._session = session
+        self._session_id = session_id
+        self._token = token
+        self._refresh = refresh
+
+    async def _refresh_token(self) -> None:
+        """Refresh the bearer token using the refresh token."""
+        payload = {"refresh_token": self._refresh}
+        try:
+            async with async_timeout.timeout(10):
+                async with self._session.post(REFRESH_URL, json=payload, headers=HEADERS) as resp:
+                    data = await resp.json()
+        except (aiohttp.ClientError, asyncio.TimeoutError) as err:  # type: ignore[name-defined]
+            _LOGGER.error("Token refresh failed: %s", err)
+            return
+
+        if "access_token" in data:
+            self._token = data["access_token"]
+        if "refresh_token" in data:
+            self._refresh = data["refresh_token"]
+
+    async def _request(self, method: str, url: str) -> Any:
+        await self._refresh_token()
+        headers = {
+            **HEADERS,
+            "w-wolt-session-id": self._session_id,
+            "authorization": f"Bearer {self._token}",
+        }
+        try:
+            async with async_timeout.timeout(10):
+                async with self._session.request(method, url, headers=headers) as resp:
+                    return await resp.json()
+        except (aiohttp.ClientError, asyncio.TimeoutError) as err:  # type: ignore[name-defined]
+            _LOGGER.error("Error requesting %s: %s", url, err)
+            return None
+
+    async def fetch_active_orders(self) -> List[Dict[str, Any]]:
+        data = await self._request("GET", ACTIVE_ORDERS_URL)
+        return data.get("orders", []) if isinstance(data, dict) else []
+
+    async def fetch_order_details(self, order_id: str) -> Dict[str, Any] | None:
+        url = ORDER_DETAILS_URL.format(order_id)
+        data = await self._request("GET", url)
+        if not isinstance(data, dict):
+            return None
+        details = data.get("order_details") or []
+        return details[0] if details else None
+
+
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    """Set up the Wolt order sensors."""
+    name = config[CONF_NAME]
+    session_id = config[CONF_SESSION_ID]
+    token = config[CONF_BEARER_TOKEN]
+    refresh = config[CONF_REFRESH_TOKEN]
+
+    session = async_get_clientsession(hass)
+    api = WoltApi(session, session_id, token, refresh)
+
+    sensors: List[WoltOrderSensor] = []
+
+    async def _update_orders(now=None) -> None:
+        orders = await api.fetch_active_orders()
+        known = {sensor.order_id for sensor in sensors}
+        new_entities = []
+        for order in orders:
+            order_id = order.get("order_id")
+            if not order_id or order_id in known:
+                continue
+            sensor = WoltOrderSensor(api, order_id, f"{name} {order_id}")
+            sensors.append(sensor)
+            new_entities.append(sensor)
+        if new_entities:
+            async_add_entities(new_entities)
+
+    await _update_orders()
+    if sensors:
+        async_add_entities(sensors, update_before_add=True)
+    else:
+        _LOGGER.info("No active orders found")
+
+    async_track_time_interval(hass, _update_orders, timedelta(seconds=UPDATE_INTERVAL))
+
+
+class WoltOrderSensor(SensorEntity):
+    """Representation of a Wolt order sensor."""
+
+    _attr_attribution = "Data provided by Wolt"
+
+    def __init__(self, api: WoltApi, order_id: str, name: str) -> None:
+        self.api = api
+        self.order_id = order_id
+        self._attr_name = name
+        self._attr_unique_id = f"wolt_{order_id}"
+        self._attr_extra_state_attributes = {}
+        self._state = None
+
+    @property
+    def native_value(self):
+        return self._state
+
+    async def async_update(self) -> None:
+        details = await self.api.fetch_order_details(self.order_id)
+        if not details:
+            _LOGGER.warning("Order %s details not found", self.order_id)
+            return
+        self._state = details.get("status")
+        self._attr_extra_state_attributes = {
+            "delivery_eta": details.get("delivery_eta"),
+            "client_pre_estimate": details.get("client_pre_estimate"),
+            "venue_name": details.get("venue_name"),
+            "payment_amount": details.get("payment_amount"),
+            "items": [item.get("name") for item in details.get("items", [])],
+        }
+        self._attr_icon = "mdi:package-variant"

--- a/custom_components/wait_for_wolt/const.py
+++ b/custom_components/wait_for_wolt/const.py
@@ -1,0 +1,27 @@
+"""Constants for the Wolt order tracker."""
+
+DOMAIN = "wait_for_wolt"
+
+CONF_SESSION_ID = "session_id"
+CONF_BEARER_TOKEN = "bearer_token"
+CONF_REFRESH_TOKEN = "refresh_token"
+
+DEFAULT_NAME = "Wolt Order"
+
+UPDATE_INTERVAL = 60  # seconds
+
+REFRESH_URL = "https://restaurant-api.wolt.com/v3/auth/token"
+ACTIVE_ORDERS_URL = "https://restaurant-api.wolt.com/v2/orders/active"
+ORDER_DETAILS_URL = (
+    "https://restaurant-api.wolt.com/v2/order_details/by_ids?purchases={}")
+
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:138.0) Gecko/20100101 Firefox/138.0",
+    "Accept": "application/json, text/plain, */*",
+    "Platform": "Web",
+    "App-Language": "en",
+    "ClientVersionNumber": "1.15.28",
+    "Client-Version": "1.15.28",
+    "App-Currency-Format": "wqQxLDIzNC41Ng==",
+    "x-wolt-web-clientid": "76cc0f70-9891-4c90-ab38-e6b5fdab4c02",
+}

--- a/custom_components/wait_for_wolt/manifest.json
+++ b/custom_components/wait_for_wolt/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "wait_for_wolt",
+  "name": "Wolt Order Tracker",
+  "documentation": "https://github.com/nitperez/ha-wait-for-wolt",
+  "issue_tracker": "https://github.com/nitperez/ha-wait-for-wolt/issues",
+  "version": "0.0.2",
+  "requirements": [],
+  "codeowners": ["@nitperez"],
+  "iot_class": "cloud_polling"
+}

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,7 @@
+{
+  "name": "Wolt Order Tracker",
+  "content_in_root": false,
+  "domain": "wait_for_wolt",
+  "homeassistant": "2024.0.0",
+  "render_readme": true
+}

--- a/info.md
+++ b/info.md
@@ -1,0 +1,3 @@
+# Wolt Order Tracker
+
+Track your Wolt deliveries in Home Assistant. Provide the session id, access token and refresh token from the Wolt web site and the integration will keep the token fresh and create sensors for all active orders.


### PR DESCRIPTION
## Summary
- require session_id, bearer_token and refresh_token instead of credentials
- refresh tokens automatically and fetch active orders
- create a sensor for each active order and update it
- document configuration and workflow

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`