### PR TITLE
Fix missing import in Wolt sensor

### DIFF
--- a/custom_components/wait_for_wolt/sensor.py
+++ b/custom_components/wait_for_wolt/sensor.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List
 
 import aiohttp
 import async_timeout
+import asyncio
 import voluptuous as vol
 
 from homeassistant.components.sensor import SensorEntity


### PR DESCRIPTION
## Summary
- add missing asyncio import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68436930b44c8331b3b32c0d2d3b40fb