### PR TITLE
Add token editing and venue instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ sensor:
       - another-venue
 ```
 
+`venue_ids` should be the slug from the venue URL on wolt.com. For example,
+`https://wolt.com/en/isr/tel-aviv/restaurant/mententen` uses `mententen` as the
+ID. Enter one ID per line or list entry.
+
 ## How it works
 - The integration refreshes the bearer token automatically.
 - Every minute it polls Wolt for your active orders.

--- a/custom_components/wait_for_wolt/config_flow.py
+++ b/custom_components/wait_for_wolt/config_flow.py
@@ -53,10 +53,46 @@ class WoltOptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_step_init(self, user_input=None):
         if user_input is not None:
-            venue_ids = [v.strip() for v in user_input.get(CONF_VENUE_IDS, "").split("\n") if v.strip()]
-            return self.async_create_entry(title="", data={CONF_VENUE_IDS: venue_ids})
+            venue_ids = [
+                v.strip()
+                for v in user_input.get(CONF_VENUE_IDS, "").split("\n")
+                if v.strip()
+            ]
 
-        current = "\n".join(self.config_entry.options.get(CONF_VENUE_IDS, self.config_entry.data.get(CONF_VENUE_IDS, [])))
-        schema = vol.Schema({vol.Optional(CONF_VENUE_IDS, default=current): str})
+            data = {**self.config_entry.data}
+            data[CONF_SESSION_ID] = user_input[CONF_SESSION_ID]
+            data[CONF_BEARER_TOKEN] = user_input[CONF_BEARER_TOKEN]
+            data[CONF_REFRESH_TOKEN] = user_input[CONF_REFRESH_TOKEN]
+
+            self.hass.config_entries.async_update_entry(
+                self.config_entry,
+                data=data,
+                options={CONF_VENUE_IDS: venue_ids},
+            )
+
+            return self.async_create_entry(title="", data={})
+
+        current = "\n".join(
+            self.config_entry.options.get(
+                CONF_VENUE_IDS, self.config_entry.data.get(CONF_VENUE_IDS, [])
+            )
+        )
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_SESSION_ID,
+                    default=self.config_entry.data.get(CONF_SESSION_ID, ""),
+                ): str,
+                vol.Required(
+                    CONF_BEARER_TOKEN,
+                    default=self.config_entry.data.get(CONF_BEARER_TOKEN, ""),
+                ): str,
+                vol.Required(
+                    CONF_REFRESH_TOKEN,
+                    default=self.config_entry.data.get(CONF_REFRESH_TOKEN, ""),
+                ): str,
+                vol.Optional(CONF_VENUE_IDS, default=current): str,
+            }
+        )
         return self.async_show_form(step_id="init", data_schema=schema)
 

--- a/custom_components/wait_for_wolt/strings.json
+++ b/custom_components/wait_for_wolt/strings.json
@@ -1,0 +1,26 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Set up Wolt account",
+        "description": "Enter tokens from wolt.com. Venue IDs are the slugs from the venue URL, one per line.",
+        "data": {
+          "session_id": "Session ID",
+          "bearer_token": "Access Token",
+          "refresh_token": "Refresh Token",
+          "venue_ids": "Venue IDs"
+        }
+      },
+      "init": {
+        "title": "Update Wolt settings",
+        "description": "Update tokens or venue IDs. Venue IDs are slugs from the venue URL, one per line.",
+        "data": {
+          "session_id": "Session ID",
+          "bearer_token": "Access Token",
+          "refresh_token": "Refresh Token",
+          "venue_ids": "Venue IDs"
+        }
+      }
+    }
+  }
+}

--- a/info.md
+++ b/info.md
@@ -1,4 +1,6 @@
 # Wolt Order Tracker
 
 Track your Wolt deliveries in Home Assistant. You can configure the integration from the UI or provide the session id, access token and refresh token in YAML. The integration will keep the token fresh and create sensors for all active orders. You can also monitor venues by adding their IDs to get open/closed status.
+Venue IDs correspond to the slug in the venue URL, for example `mententen` in
+`https://wolt.com/en/isr/tel-aviv/restaurant/mententen`.
 


### PR DESCRIPTION
## Summary
- allow editing tokens via the options flow
- add descriptions to the config forms
- document venue ID format in README and info

## Testing
- `python -m py_compile custom_components/wait_for_wolt/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684369bd7d10833185949e7e7e802b9a