### PR TITLE
Fix token refresh endpoint

### DIFF
--- a/custom_components/wait_for_wolt/const.py
+++ b/custom_components/wait_for_wolt/const.py
@@ -11,7 +11,7 @@ DEFAULT_NAME = "Wolt Order"
 
 UPDATE_INTERVAL = 60  # seconds
 
-REFRESH_URL = "https://restaurant-api.wolt.com/v3/auth/token"
+REFRESH_URL = "https://converse-api.wolt.com/auth-api/v2/token"
 ACTIVE_ORDERS_URL = "https://restaurant-api.wolt.com/v2/orders/active"
 ORDER_DETAILS_URL = (
     "https://restaurant-api.wolt.com/v2/order_details/by_ids?purchases={}")

--- a/custom_components/wait_for_wolt/sensor.py
+++ b/custom_components/wait_for_wolt/sensor.py
@@ -103,7 +103,12 @@ class WoltApi:
 
     async def _refresh_token(self) -> None:
         """Refresh the bearer token using the refresh token."""
-        payload = {"refresh_token": self._refresh}
+        payload = {
+            "grantType": "refresh_token",
+            "audience": "converse_widget",
+            "refreshToken": self._refresh,
+            "appId": "wolt-consumer",
+        }
         try:
             async with async_timeout.timeout(10):
                 async with self._session.post(REFRESH_URL, json=payload, headers=HEADERS) as resp:
@@ -112,10 +117,10 @@ class WoltApi:
             _LOGGER.error("Token refresh failed: %s", err)
             return
 
-        if "access_token" in data:
-            self._token = data["access_token"]
-        if "refresh_token" in data:
-            self._refresh = data["refresh_token"]
+        if "accessToken" in data:
+            self._token = data["accessToken"]
+        if "refreshToken" in data:
+            self._refresh = data["refreshToken"]
 
     async def _request(self, method: str, url: str, auth: bool = True) -> Any:
         """Make a request and return the parsed JSON response."""


### PR DESCRIPTION
## Summary
- update the Wolt token refresh URL
- send new payload fields for the refresh call
- parse the updated token names in responses

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68436cb578248331b19fea27e2eaa2af