### PR TITLE
Update Wolt API URLs

### DIFF
--- a/custom_components/wait_for_wolt/const.py
+++ b/custom_components/wait_for_wolt/const.py
@@ -12,9 +12,13 @@ DEFAULT_NAME = "Wolt Order"
 UPDATE_INTERVAL = 60  # seconds
 
 REFRESH_URL = "https://converse-api.wolt.com/auth-api/v2/token"
-ACTIVE_ORDERS_URL = "https://restaurant-api.wolt.com/v2/orders/active"
+# Updated endpoints based on the current Wolt web client
+ACTIVE_ORDERS_URL = (
+    "https://consumer-api.wolt.com/order-xp/web/v1/pages/orders"
+)
 ORDER_DETAILS_URL = (
-    "https://restaurant-api.wolt.com/v2/order_details/by_ids?purchases={}")
+    "https://consumer-api.wolt.com/order-xp/web/v1/pages/orders/{}"
+)
 VENUE_CONTENT_URL = (
     "https://consumer-api.wolt.com/consumer-api/venue-content-api/v3/web/venue-content/slug/{}"
 )


### PR DESCRIPTION
## Summary
- update API endpoints for active orders and order details

## Testing
- `python3 -m py_compile custom_components/wait_for_wolt/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68436ecfea3c8331b56e18a799dbadf8