### PR TITLE
docs: establish contributor and security foundations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @selfish

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,68 @@
+name: Bug report
+description: Report a reproducible problem without sharing private data
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a problem. **Never include Wolt tokens, cookies, authorization headers, HAR files, addresses, order/purchase IDs, item histories, or courier coordinates.** Use synthetic placeholders and redact screenshots/logs.
+  - type: input
+    id: version
+    attributes:
+      label: Integration version or commit
+      placeholder: v0.1.0 or a commit SHA
+    validations:
+      required: true
+  - type: input
+    id: ha_version
+    attributes:
+      label: Home Assistant version
+      placeholder: 2026.7.3
+    validations:
+      required: true
+  - type: dropdown
+    id: installation
+    attributes:
+      label: Installation method
+      options:
+        - HACS custom repository
+        - Manual custom_components copy
+        - Development checkout
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe expected and actual behavior with private values replaced by synthetic placeholders.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction steps
+      placeholder: |
+        1. Add the integration...
+        2. Place a test order...
+        3. Observe...
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Redacted logs
+      description: Include only relevant lines. Remove tokens, cookies, personal/order data, addresses, IDs, and coordinates.
+      render: text
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Privacy and duplicate checks
+      options:
+        - label: I searched existing issues and pull requests.
+          required: true
+        - label: I removed all credentials and private Wolt/Home Assistant data.
+          required: true
+        - label: This is not a security vulnerability requiring private disclosure.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/selfish/ha-wait-for-wolt/security/policy
+    about: Read the private-reporting instructions before sharing security details.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature request
+description: Propose a Home Assistant or Wolt-tracking improvement
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Explain the user outcome rather than only the implementation. Remember that Wolt's consumer API is private and unsupported; proposed polling must be conservative.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or automation goal
+      description: What are you trying to accomplish in Home Assistant?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: Describe entities, events, services, or UI behavior and any useful alternatives.
+    validations:
+      required: true
+  - type: textarea
+    id: api_impact
+    attributes:
+      label: Wolt API and privacy impact
+      description: Note new endpoints, polling frequency, stored data, or diagnostics implications. Do not include real payloads or credentials.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I searched existing issues and pull requests.
+          required: true
+        - label: I have not included tokens, cookies, addresses, order data, IDs, or courier coordinates.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+## Problem
+
+<!-- What user-visible or maintenance problem does this solve? Link the issue. -->
+
+## Approach
+
+<!-- Summarize the implementation and important trade-offs. -->
+
+## Privacy and API impact
+
+- [ ] No real Wolt/Home Assistant credentials, account data, order data, addresses, or courier locations are included.
+- [ ] Fixtures are minimal and synthetic.
+- [ ] Polling/request behavior is unchanged, or the change is explained below.
+
+## Verification
+
+<!-- List commands actually run and their results. -->
+
+- [ ] `uv run ruff check .`
+- [ ] `uv run ruff format --check .`
+- [ ] `uv run pytest`
+- [ ] Hassfest/HACS validation, when applicable
+
+## Home Assistant compatibility
+
+<!-- Note entity-ID, unique-ID, config-entry, migration, diagnostics, or reauthentication effects. -->
+
+## Screenshots or diagnostics
+
+<!-- Optional. Redact aggressively. Never attach tokens, cookies, HAR files, addresses, order IDs, purchase IDs, or courier coordinates. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to Wolt Order Tracker will be documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Offline Home Assistant tests with synthetic fixtures.
+- Ruff, locked Python tooling, Hassfest, HACS validation, Dependabot, and exact-commit review packages.
+- MIT license and contributor/security guidance.
+
+### Changed
+
+- Wolt analytics session ID is optional.
+- Active-order discovery accepts Wolt's current `purchase_id` field.
+- Access tokens are refreshed only after an unauthorized response, using Wolt's current web refresh flow.
+
+### Security
+
+- Rotated credentials are persisted without being logged.
+- Documentation and tests explicitly prohibit real Wolt or Home Assistant secrets.
+
+[Unreleased]: https://github.com/selfish/ha-wait-for-wolt/compare/main...HEAD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing
+
+Thanks for helping improve Wolt Order Tracker. This is an unofficial Home Assistant integration built on Wolt's private consumer web API, so reliability, privacy, and conservative request behavior are core requirements.
+
+## Before opening a change
+
+- Search existing issues and pull requests.
+- For API-contract changes, describe the observed behavior without sharing account data or credentials.
+- Keep changes focused. Large architecture changes should start with an issue.
+
+## Local setup
+
+Install [uv](https://docs.astral.sh/uv/), then run:
+
+```bash
+uv sync --frozen
+uv run ruff check .
+uv run ruff format --check .
+uv run pytest
+```
+
+See [Development and verification](docs/DEVELOPMENT.md) for the full workflow and exact-commit review artifacts.
+
+## Privacy rules
+
+Never commit or paste real:
+
+- Wolt access or refresh tokens;
+- cookies, session identifiers, HAR files, or authorization headers;
+- names, phone numbers, addresses, order IDs, purchase IDs, courier coordinates, or item histories;
+- Home Assistant URLs, tokens, diagnostics containing credentials, or entity-registry exports.
+
+Tests must use minimal synthetic fixtures with obviously fake values such as `sanitized-purchase-001`. Reduce real payloads to the smallest synthetic shape needed to reproduce the behavior.
+
+## Code and architecture
+
+- Follow current Home Assistant integration patterns.
+- Keep network logic in the API client and shared polling in a `DataUpdateCoordinator`.
+- Classify authentication, connectivity, rate-limit, and payload errors explicitly.
+- Do not log tokens or full API payloads.
+- Preserve stable entity unique IDs and include migration tests for changes.
+- Keep polling conservative; Wolt does not publish a supported API for this use.
+- Add tests before or alongside behavior changes.
+
+## Pull requests
+
+A pull request should explain the problem, the approach, privacy considerations, and real verification performed. CI must pass Ruff, pytest, Hassfest, HACS validation, and exact-commit packaging before merge.
+
+By contributing, you agree that your contribution is licensed under the repository's MIT license.

--- a/README.md
+++ b/README.md
@@ -80,4 +80,6 @@ ID on a new line.
 ## Development
 
 See [Development and verification](docs/DEVELOPMENT.md) for locked setup commands,
-sanitized-fixture rules, CI validation, and exact-commit review artifacts.
+sanitized-fixture rules, CI validation, and exact-commit review artifacts. Contributions
+must follow the [contributor guide](CONTRIBUTING.md) and [security policy](SECURITY.md).
+Release-facing changes are recorded in the [changelog](CHANGELOG.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security policy
+
+## Supported versions
+
+Until the first stable release, only the latest release and the current `main` branch receive security fixes.
+
+## Reporting a vulnerability
+
+Use GitHub's **Report a vulnerability** option on the repository Security tab whenever it is available. Do not disclose a vulnerability publicly before a fix is ready.
+
+If private reporting is unavailable, open a minimal issue asking the maintainer for a private contact channel. Do **not** include exploit details, Wolt cookies or tokens, Home Assistant credentials, addresses, order data, courier locations, HAR files, screenshots containing account data, or logs containing secrets.
+
+Include, through the private channel:
+
+- the affected integration version or commit;
+- the Home Assistant version;
+- impact and reproducible steps using synthetic/redacted values;
+- any suggested mitigation.
+
+You should receive an acknowledgement within seven days. Timing for a fix and disclosure will depend on severity and whether the issue originates in this integration or Wolt's private consumer API.
+
+## Credential handling
+
+Treat Wolt access tokens, refresh tokens, session cookies, Home Assistant tokens, and captured browser traffic as passwords. The project will never ask you to post them in a public issue, test fixture, pull request, or chat.


### PR DESCRIPTION
## Summary

- add a security policy with private-disclosure and strict credential/privacy rules
- add a contributor guide for current Home Assistant architecture, conservative Wolt API use, synthetic fixtures, and the locked local quality gate
- add CODEOWNERS, structured bug/feature forms, a pull-request template, and issue-routing configuration
- start a Keep a Changelog-compatible changelog and link the repository guidance from the README

## Verification

- parsed every issue-template YAML file with PyYAML
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `uv run pytest` — 18 passed
- `git diff --check` — passed

## Repository-admin follow-up

The repository-scoped GitHub App returned HTTP 403 when enabling private vulnerability reporting. The security policy includes a safe fallback, but the owner should enable **Settings → Security → Private vulnerability reporting** when repository administration access is available.
