### PR TITLE
refactor: extract and harden Wolt API client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Offline Home Assistant tests with synthetic fixtures.
 - Ruff, locked Python tooling, Hassfest, HACS validation, Dependabot, and exact-commit review packages.
 - MIT license and contributor/security guidance.
+- A Home Assistant-independent Wolt API client with typed authentication,
+  connectivity, rate-limit, and payload errors.
+- Rich purchase-tracking endpoint support with current and legacy response-shape
+  compatibility.
 
 ### Changed
 
 - Wolt analytics session ID is optional.
 - Active-order discovery accepts Wolt's current `purchase_id` field.
 - Access tokens are refreshed only after an unauthorized response, using Wolt's current web refresh flow.
+- Completed order history is filtered out before entities are created.
+- Legacy YAML configuration is imported once into a durable config entry and is
+  deprecated as a runtime credential source.
+- The minimum supported Home Assistant version is now 2026.7.0, matching the
+  tested Python and Home Assistant environment.
+
+### Fixed
+
+- Credential-only options edits now reload the running API client.
+- Concurrent unauthorized requests share one serialized token refresh instead
+  of racing rotating refresh tokens.
+- Malformed JSON responses become typed payload errors instead of escaping the
+  integration update path.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # ha-wait-for-wolt
 
-This custom component tracks your Wolt orders in Home Assistant. It polls the Wolt API using tokens that you obtain once from the web site and keeps them refreshed automatically.
+This custom component tracks your Wolt orders in Home Assistant. It polls the Wolt API using tokens that you obtain once from the web site and persists refreshed credentials in a Home Assistant config entry.
 
 ## Installation via HACS
+Requires Home Assistant 2026.7.0 or newer.
+
 1. Add this repository as a custom repository in [HACS](https://hacs.xyz/).
 2. Install **Wolt Order Tracker** and restart Home Assistant.
 
@@ -43,8 +45,13 @@ capture them is from your web browser after logging in.
 
 
 ## Configuration
-You can add the integration from Home Assistant's **Add Integration** menu or via YAML.
-To configure with YAML, add a sensor entry to `configuration.yaml`:
+Add the integration from Home Assistant's **Add Integration** menu. This is the
+supported configuration path and keeps rotated Wolt credentials durable across
+Home Assistant restarts.
+
+Legacy YAML is imported once for migration. If you already have the following
+sensor entry, restart Home Assistant, confirm that the UI integration was created,
+then remove the YAML block:
 
 ```yaml
 sensor:
@@ -58,6 +65,9 @@ sensor:
       - mententen
       - another-venue
 ```
+
+Do not keep YAML as a credential backup: Wolt may rotate refresh tokens, and the
+imported config entry becomes the authoritative credential store.
 
 `venue_ids` should be the slug from the venue URL on wolt.com. For example,
 `https://wolt.com/en/isr/tel-aviv/restaurant/mententen` uses `mententen` as the

--- a/custom_components/wait_for_wolt/__init__.py
+++ b/custom_components/wait_for_wolt/__init__.py
@@ -14,6 +14,11 @@ PLATFORMS = [Platform.SENSOR]
 CONFIG_SCHEMA = cv.platform_only_config_schema(DOMAIN)
 
 
+def _entry_snapshot(entry: ConfigEntry) -> dict[str, dict]:
+    """Return the entry values used by the currently loaded runtime."""
+    return {"data": dict(entry.data), "options": dict(entry.options)}
+
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up via YAML (handled by the sensor platform)."""
     return True
@@ -21,9 +26,13 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Forward config entry setup to the sensor platform."""
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = dict(entry.options)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = _entry_snapshot(entry)
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    try:
+        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    except Exception:
+        hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
+        raise
     return True
 
 
@@ -37,6 +46,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload after user options change, but not after token rotation."""
-    if hass.data.get(DOMAIN, {}).get(entry.entry_id) == entry.options:
+    if hass.data.get(DOMAIN, {}).get(entry.entry_id) == _entry_snapshot(entry):
         return
     await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/wait_for_wolt/api.py
+++ b/custom_components/wait_for_wolt/api.py
@@ -1,0 +1,275 @@
+"""Home Assistant-independent asynchronous client for Wolt endpoints."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Awaitable, Callable
+from typing import Any
+from urllib.parse import quote
+
+import aiohttp
+
+from .const import (
+    ACTIVE_ORDERS_URL,
+    HEADERS,
+    ORDER_DETAILS_URL,
+    REFRESH_URL,
+    VENUE_CONTENT_URL,
+)
+
+REQUEST_TIMEOUT = 10
+
+TokenUpdateCallback = Callable[[str, str], Awaitable[None] | None]
+
+FINAL_ORDER_STATUS_TYPES = {
+    "DELIVERED",
+    "CANCELED",
+    "CANCELLED",
+    "REFUNDED",
+    "REJECTED",
+    "FAILED",
+}
+
+
+def _active_order(order: dict[str, Any]) -> bool:
+    """Return whether an order-list item represents a trackable active order."""
+    telemetry = order.get("telemetry")
+    status_type = (
+        telemetry.get("order_status_type")
+        if isinstance(telemetry, dict)
+        else order.get("order_status_type")
+    )
+    if status_type:
+        normalized = str(status_type).upper()
+        if normalized == "IN_PROGRESS":
+            return True
+        if normalized in FINAL_ORDER_STATUS_TYPES:
+            return False
+
+    call_to_action = order.get("call_to_action")
+    if isinstance(call_to_action, dict):
+        action = call_to_action.get("link") or call_to_action.get("type")
+        if action and "ORDER_TRACKING" in str(action).upper():
+            return True
+
+    status = order.get("status")
+    if isinstance(status, dict):
+        status = status.get("value") or status.get("text") or status.get("label")
+    if not isinstance(status, str) or not status:
+        return False
+    return not any(
+        final_word in status.lower()
+        for final_word in ("delivered", "cancel", "failed", "refunded", "rejected")
+    )
+
+
+class WoltApiError(Exception):
+    """Base class for Wolt API failures."""
+
+
+class WoltAuthenticationError(WoltApiError):
+    """The access or refresh credentials were rejected."""
+
+    def __init__(self, message: str, *, status: int | None = None) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+class WoltConnectionError(WoltApiError):
+    """Wolt could not be reached or returned an unsuccessful response."""
+
+    def __init__(self, message: str, *, status: int | None = None) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+class WoltRateLimitError(WoltConnectionError):
+    """Wolt rejected a request because its rate limit was reached."""
+
+
+class WoltInvalidPayloadError(WoltApiError):
+    """Wolt returned JSON with an incompatible shape."""
+
+
+class WoltApi:
+    """Asynchronous client for the Wolt endpoints used by this integration."""
+
+    def __init__(
+        self,
+        session: aiohttp.ClientSession,
+        session_id: str | None,
+        access_token: str,
+        refresh_token: str,
+        *,
+        token_update_callback: TokenUpdateCallback | None = None,
+    ) -> None:
+        self._session = session
+        self._session_id = session_id
+        self._access_token = access_token
+        self._refresh_token = refresh_token
+        self._token_update_callback = token_update_callback
+        self._refresh_lock = asyncio.Lock()
+
+    @property
+    def access_token(self) -> str:
+        """Return the currently active access token."""
+        return self._access_token
+
+    @property
+    def refresh_token(self) -> str:
+        """Return the currently active refresh token."""
+        return self._refresh_token
+
+    def _headers(self, *, authenticated: bool) -> dict[str, str]:
+        """Build fresh request headers without mutating shared constants."""
+        headers = dict(HEADERS)
+        if authenticated:
+            headers["authorization"] = f"Bearer {self._access_token}"
+            if self._session_id:
+                headers["w-wolt-session-id"] = self._session_id
+        return headers
+
+    async def _perform_request(
+        self,
+        method: str,
+        url: str,
+        *,
+        authenticated: bool,
+        data: dict[str, str] | None = None,
+    ) -> Any:
+        """Perform one request and translate transport/status/payload failures."""
+        headers = self._headers(authenticated=authenticated)
+        try:
+            async with asyncio.timeout(REQUEST_TIMEOUT):
+                if method == "POST":
+                    request = self._session.post(url, headers=headers, data=data)
+                else:
+                    request = self._session.request(method, url, headers=headers)
+                async with request as response:
+                    if response.status in (401, 403):
+                        raise WoltAuthenticationError(
+                            "Wolt rejected the supplied credentials",
+                            status=response.status,
+                        )
+                    if response.status == 429:
+                        raise WoltRateLimitError("Wolt rate limit reached")
+                    if response.status >= 400:
+                        raise WoltConnectionError(
+                            f"Wolt request failed with status {response.status}",
+                            status=response.status,
+                        )
+                    try:
+                        return await response.json()
+                    except (aiohttp.ContentTypeError, TypeError, ValueError) as err:
+                        raise WoltInvalidPayloadError(
+                            "Wolt returned invalid JSON"
+                        ) from err
+        except WoltApiError, asyncio.CancelledError:
+            raise
+        except (TimeoutError, aiohttp.ClientError) as err:
+            raise WoltConnectionError("Unable to connect to Wolt") from err
+
+    async def _refresh_access_token(self) -> None:
+        """Refresh credentials with Wolt's form-encoded web authentication flow."""
+        payload = {
+            "grant_type": "refresh_token",
+            "refresh_token": self._refresh_token,
+        }
+        try:
+            data = await self._perform_request(
+                "POST",
+                REFRESH_URL,
+                authenticated=False,
+                data=payload,
+            )
+        except WoltConnectionError as err:
+            if err.status == 400:
+                raise WoltAuthenticationError(
+                    "Wolt rejected the supplied refresh token", status=err.status
+                ) from err
+            raise
+        if not isinstance(data, dict):
+            raise WoltInvalidPayloadError("Wolt token refresh returned a non-object")
+
+        access_token = data.get("access_token") or data.get("accessToken")
+        if not isinstance(access_token, str) or not access_token:
+            raise WoltInvalidPayloadError(
+                "Wolt token refresh did not return an access token"
+            )
+
+        refresh_token = data.get("refresh_token") or data.get("refreshToken")
+        if refresh_token is None:
+            refresh_token = self._refresh_token
+        if not isinstance(refresh_token, str) or not refresh_token:
+            raise WoltInvalidPayloadError(
+                "Wolt token refresh returned an invalid refresh token"
+            )
+
+        self._access_token = access_token
+        self._refresh_token = refresh_token
+
+        if self._token_update_callback is not None:
+            callback_result = self._token_update_callback(access_token, refresh_token)
+            if inspect.isawaitable(callback_result):
+                await callback_result
+
+    async def _request(self, method: str, url: str, *, auth: bool = True) -> Any:
+        """Request JSON, refreshing and retrying once only after an initial 401."""
+        rejected_access_token = self._access_token
+        try:
+            return await self._perform_request(
+                method,
+                url,
+                authenticated=auth,
+            )
+        except WoltAuthenticationError as err:
+            if not auth or err.status != 401:
+                raise
+
+        async with self._refresh_lock:
+            # Another concurrent request may already have rotated the token while
+            # this request was waiting for the lock. Reuse that token rather than
+            # submitting the same single-use refresh token twice.
+            if self._access_token == rejected_access_token:
+                await self._refresh_access_token()
+        return await self._perform_request(method, url, authenticated=True)
+
+    async def fetch_active_orders(self) -> list[dict[str, Any]]:
+        """Fetch the account's active orders."""
+        data = await self._request("GET", ACTIVE_ORDERS_URL)
+        if not isinstance(data, dict) or not isinstance(data.get("orders"), list):
+            raise WoltInvalidPayloadError("Wolt active orders payload is invalid")
+        return [
+            order
+            for order in data["orders"]
+            if isinstance(order, dict) and _active_order(order)
+        ]
+
+    async def fetch_order_details(self, purchase_id: str) -> dict[str, Any]:
+        """Fetch rich purchase-tracking details for an order."""
+        data = await self._request(
+            "GET", ORDER_DETAILS_URL.format(quote(purchase_id, safe=""))
+        )
+        if not isinstance(data, dict):
+            raise WoltInvalidPayloadError("Wolt order details payload is invalid")
+        details = data.get("order_details")
+        if isinstance(details, dict):
+            return details
+        if isinstance(details, list) and details and isinstance(details[0], dict):
+            return details[0]
+        raise WoltInvalidPayloadError("Wolt order details payload is invalid")
+
+    async def fetch_venue_details(self, slug: str) -> dict[str, Any]:
+        """Fetch public venue details without sending account credentials."""
+        data = await self._request(
+            "GET",
+            VENUE_CONTENT_URL.format(quote(slug, safe="")),
+            auth=False,
+        )
+        if not isinstance(data, dict):
+            raise WoltInvalidPayloadError("Wolt venue payload is invalid")
+        venue = data.get("venue") or data.get("venue_info")
+        if not isinstance(venue, dict):
+            raise WoltInvalidPayloadError("Wolt venue payload is invalid")
+        return data

--- a/custom_components/wait_for_wolt/config_flow.py
+++ b/custom_components/wait_for_wolt/config_flow.py
@@ -46,6 +46,22 @@ class WoltConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(step_id="user", data_schema=self.DATA_SCHEMA)
 
+    async def async_step_import(self, import_data):
+        """Import a legacy YAML platform into a durable config entry."""
+        if self._async_current_entries():
+            return self.async_abort(reason="already_configured")
+
+        data = dict(import_data)
+        data[CONF_SESSION_ID] = data.get(CONF_SESSION_ID, "")
+        venues = data.get(CONF_VENUE_IDS, [])
+        if isinstance(venues, str):
+            venues = [venue.strip() for venue in venues.split("\n") if venue.strip()]
+        data[CONF_VENUE_IDS] = list(venues)
+        return self.async_create_entry(
+            title=data.get(CONF_NAME, DEFAULT_NAME),
+            data=data,
+        )
+
     @staticmethod
     def async_get_options_flow(config_entry):
         return WoltOptionsFlowHandler(config_entry)
@@ -62,6 +78,7 @@ class WoltOptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
                 if v.strip()
             ]
 
+            options = {CONF_VENUE_IDS: venue_ids}
             self.hass.config_entries.async_update_entry(
                 self.config_entry,
                 data={
@@ -70,10 +87,11 @@ class WoltOptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
                     CONF_BEARER_TOKEN: user_input[CONF_BEARER_TOKEN],
                     CONF_REFRESH_TOKEN: user_input[CONF_REFRESH_TOKEN],
                 },
+                options=options,
             )
             return self.async_create_entry(
                 title="",
-                data={CONF_VENUE_IDS: venue_ids},
+                data=options,
             )
 
         current = "\n".join(

--- a/custom_components/wait_for_wolt/const.py
+++ b/custom_components/wait_for_wolt/const.py
@@ -14,7 +14,9 @@ UPDATE_INTERVAL = 60  # seconds
 REFRESH_URL = "https://authentication.wolt.com/v1/wauth2/access_token"
 # Updated endpoints based on the current Wolt web client
 ACTIVE_ORDERS_URL = "https://consumer-api.wolt.com/order-xp/web/v1/pages/orders"
-ORDER_DETAILS_URL = "https://consumer-api.wolt.com/order-xp/web/v1/pages/orders/{}"
+ORDER_DETAILS_URL = (
+    "https://restaurant-api.wolt.com/v2/order_details/purchase_tracking?purchase_id={}"
+)
 VENUE_CONTENT_URL = "https://consumer-api.wolt.com/order-xp/web/v1/venue/slug/{}/dynamic/?selected_delivery_method=homedelivery"
 
 HEADERS = {

--- a/custom_components/wait_for_wolt/sensor.py
+++ b/custom_components/wait_for_wolt/sensor.py
@@ -2,17 +2,15 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from collections.abc import Callable
 from datetime import timedelta
 from typing import Any
 
-import aiohttp
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -20,18 +18,15 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
+from .api import WoltApi, WoltApiError
 from .const import (
-    ACTIVE_ORDERS_URL,
     CONF_BEARER_TOKEN,
     CONF_REFRESH_TOKEN,
     CONF_SESSION_ID,
     CONF_VENUE_IDS,
     DEFAULT_NAME,
-    HEADERS,
-    ORDER_DETAILS_URL,
-    REFRESH_URL,
+    DOMAIN,
     UPDATE_INTERVAL,
-    VENUE_CONTENT_URL,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -59,7 +54,31 @@ async def _setup_sensors(
 ) -> Callable[[], None]:
     """Create sensors and schedule updates."""
     session = async_get_clientsession(hass)
-    api = WoltApi(session, session_id, token, refresh, hass=hass, entry=entry)
+
+    def _persist_tokens(access_token: str, refresh_token: str) -> None:
+        if entry is None:
+            return
+        updated_data = {
+            **entry.data,
+            CONF_BEARER_TOKEN: access_token,
+            CONF_REFRESH_TOKEN: refresh_token,
+        }
+        runtime = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+        if isinstance(runtime, dict):
+            runtime["data"] = dict(updated_data)
+            runtime["options"] = dict(entry.options)
+        hass.config_entries.async_update_entry(
+            entry,
+            data=updated_data,
+        )
+
+    api = WoltApi(
+        session,
+        session_id,
+        token,
+        refresh,
+        token_update_callback=_persist_tokens if entry is not None else None,
+    )
 
     sensors: list[WoltOrderSensor] = []
     venue_sensors: list[WoltVenueSensor] = []
@@ -70,7 +89,11 @@ async def _setup_sensors(
         async_add_entities(venue_sensors, update_before_add=True)
 
     async def _update_orders(now=None, *, update_before_add: bool = False) -> None:
-        orders = await api.fetch_active_orders()
+        try:
+            orders = await api.fetch_active_orders()
+        except WoltApiError as err:
+            _LOGGER.warning("Unable to fetch active Wolt orders: %s", err)
+            return
         known = {sensor.order_id for sensor in sensors}
         new_entities = []
         for order in orders:
@@ -92,143 +115,28 @@ async def _setup_sensors(
     )
 
 
-class WoltApi:
-    """Simple wrapper for the Wolt API."""
-
-    def __init__(
-        self,
-        session: aiohttp.ClientSession,
-        session_id: str,
-        token: str,
-        refresh: str,
-        *,
-        hass: HomeAssistant | None = None,
-        entry: ConfigEntry | None = None,
-    ) -> None:
-        self._session = session
-        self._session_id = session_id
-        self._token = token
-        self._refresh = refresh
-        self._hass = hass
-        self._entry = entry
-
-    async def _refresh_token(self) -> bool:
-        """Refresh and persist the bearer token using Wolt's current web flow."""
-        payload = {
-            "grant_type": "refresh_token",
-            "refresh_token": self._refresh,
-        }
-        try:
-            async with asyncio.timeout(10):
-                async with self._session.post(
-                    REFRESH_URL, data=payload, headers=HEADERS
-                ) as resp:
-                    resp.raise_for_status()
-                    data = await resp.json()
-        except (TimeoutError, aiohttp.ClientError) as err:
-            _LOGGER.error("Token refresh failed: %s", err)
-            return False
-
-        access_token = (
-            data.get("access_token") or data.get("accessToken")
-            if isinstance(data, dict)
-            else None
-        )
-        if not isinstance(access_token, str):
-            _LOGGER.error("Token refresh returned an invalid response")
-            return False
-
-        self._token = access_token
-        refresh_token = data.get("refresh_token") or data.get("refreshToken")
-        if isinstance(refresh_token, str):
-            self._refresh = refresh_token
-        if self._entry is not None and self._hass is not None:
-            self._hass.config_entries.async_update_entry(
-                self._entry,
-                data={
-                    **self._entry.data,
-                    CONF_BEARER_TOKEN: self._token,
-                    CONF_REFRESH_TOKEN: self._refresh,
-                },
-            )
-        return True
-
-    async def _request(self, method: str, url: str, auth: bool = True) -> Any:
-        """Make a request, refreshing and retrying once only after a 401."""
-        headers = {**HEADERS}
-        if auth:
-            headers["authorization"] = f"Bearer {self._token}"
-            if self._session_id:
-                headers["w-wolt-session-id"] = self._session_id
-        try:
-            async with asyncio.timeout(10):
-                async with self._session.request(method, url, headers=headers) as resp:
-                    if auth and resp.status == 401:
-                        if not await self._refresh_token():
-                            return None
-                        retry_headers = {
-                            **headers,
-                            "authorization": f"Bearer {self._token}",
-                        }
-                        async with self._session.request(
-                            method, url, headers=retry_headers
-                        ) as retry_resp:
-                            retry_resp.raise_for_status()
-                            return await retry_resp.json()
-                    resp.raise_for_status()
-                    return await resp.json()
-        except (TimeoutError, aiohttp.ClientError, aiohttp.ContentTypeError) as err:
-            _LOGGER.error("Error requesting %s: %s", url, err)
-            return None
-
-    async def fetch_active_orders(self) -> list[dict[str, Any]]:
-        data = await self._request("GET", ACTIVE_ORDERS_URL)
-        if not isinstance(data, dict):
-            return []
-        orders = data.get("orders")
-        if not isinstance(orders, list):
-            return []
-        return [order for order in orders if isinstance(order, dict)]
-
-    async def fetch_order_details(self, order_id: str) -> dict[str, Any] | None:
-        url = ORDER_DETAILS_URL.format(order_id)
-        data = await self._request("GET", url)
-        if not isinstance(data, dict):
-            return None
-        details = data.get("order_details")
-        if not isinstance(details, list) or not details:
-            return None
-        return details[0] if isinstance(details[0], dict) else None
-
-    async def fetch_venue_details(self, slug: str) -> dict[str, Any] | None:
-        url = VENUE_CONTENT_URL.format(slug)
-        # Public endpoint - do not send authentication headers
-        data = await self._request("GET", url, auth=False)
-        if not isinstance(data, dict):
-            _LOGGER.warning("Bad response for venue: %s: %s", slug, data)
-            return None
-        venue = data.get("venue") or data.get("venue_info")
-        if not isinstance(venue, dict):
-            _LOGGER.warning("Bad response for venue: %s", slug)
-            return None
-        return data
-
-
 async def async_setup_platform(
     hass: HomeAssistant,
     config: ConfigType,
     async_add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
-    """Set up Wolt sensors from YAML."""
-    name = config[CONF_NAME]
-    session_id = config.get(CONF_SESSION_ID, "")
-    token = config[CONF_BEARER_TOKEN]
-    refresh = config[CONF_REFRESH_TOKEN]
-
-    venues = config.get(CONF_VENUE_IDS, [])
-    await _setup_sensors(
-        hass, async_add_entities, name, session_id, token, refresh, venues
+    """Import legacy YAML into a config entry with durable token rotation."""
+    del async_add_entities, discovery_info
+    _LOGGER.warning(
+        "YAML configuration for wait_for_wolt is deprecated; importing it into "
+        "the Home Assistant integration UI. Remove the YAML after import"
+    )
+    await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data={
+            CONF_NAME: config[CONF_NAME],
+            CONF_SESSION_ID: config.get(CONF_SESSION_ID, ""),
+            CONF_BEARER_TOKEN: config[CONF_BEARER_TOKEN],
+            CONF_REFRESH_TOKEN: config[CONF_REFRESH_TOKEN],
+            CONF_VENUE_IDS: config.get(CONF_VENUE_IDS, []),
+        },
     )
 
 
@@ -244,7 +152,7 @@ async def async_setup_entry(
         hass,
         async_add_entities,
         data.get(CONF_NAME, DEFAULT_NAME),
-        data[CONF_SESSION_ID],
+        data.get(CONF_SESSION_ID, ""),
         data[CONF_BEARER_TOKEN],
         data[CONF_REFRESH_TOKEN],
         venues,
@@ -272,13 +180,23 @@ class WoltOrderSensor(SensorEntity):
         return self._state
 
     async def async_update(self) -> None:
-        details = await self.api.fetch_order_details(self.order_id)
+        try:
+            details = await self.api.fetch_order_details(self.order_id)
+        except WoltApiError as err:
+            self._attr_available = False
+            _LOGGER.warning("Unable to update Wolt order %s: %s", self.order_id, err)
+            return
         if not details:
             self._attr_available = False
             _LOGGER.warning("Order %s details not found", self.order_id)
             return
         self._attr_available = True
-        self._state = details.get("status")
+        status = details.get("status")
+        if isinstance(status, dict):
+            status = status.get("value") or status.get("text") or status.get("label")
+        if status is None:
+            status = details.get("order_status_type")
+        self._state = str(status) if status is not None else None
         items = details.get("items")
         self._attr_extra_state_attributes = {
             "delivery_eta": details.get("delivery_eta"),
@@ -312,7 +230,12 @@ class WoltVenueSensor(SensorEntity):
         return self._state
 
     async def async_update(self) -> None:
-        details = await self.api.fetch_venue_details(self.slug)
+        try:
+            details = await self.api.fetch_venue_details(self.slug)
+        except WoltApiError as err:
+            self._attr_available = False
+            _LOGGER.warning("Unable to update Wolt venue %s: %s", self.slug, err)
+            return
         if not details:
             self._attr_available = False
             _LOGGER.warning("Venue %s details not found", self.slug)

--- a/custom_components/wait_for_wolt/strings.json
+++ b/custom_components/wait_for_wolt/strings.json
@@ -1,5 +1,8 @@
 {
   "config": {
+    "abort": {
+      "already_configured": "A Wolt account is already configured. Remove the legacy YAML block after it has been imported."
+    },
     "step": {
       "user": {
         "title": "Set up Wolt account",

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "Wolt Order Tracker",
   "content_in_root": false,
-  "homeassistant": "2024.0.0",
+  "homeassistant": "2026.7.0",
   "render_readme": true
 }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,240 +1,356 @@
-"""Tests for Wolt API request and payload handling."""
+"""Synthetic offline tests for the Home Assistant-independent Wolt API client."""
 
-import json
-from collections.abc import Callable
-from pathlib import Path
+import asyncio
+from collections import deque
 from typing import Any
-from unittest.mock import AsyncMock
 
 import aiohttp
 import pytest
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClientMocker
 
+from custom_components.wait_for_wolt.api import (
+    WoltApi,
+    WoltAuthenticationError,
+    WoltConnectionError,
+    WoltInvalidPayloadError,
+    WoltRateLimitError,
+)
 from custom_components.wait_for_wolt.const import (
     ACTIVE_ORDERS_URL,
+    ORDER_DETAILS_URL,
     REFRESH_URL,
     VENUE_CONTENT_URL,
 )
-from custom_components.wait_for_wolt.sensor import WoltApi
 
 
-@pytest.fixture
-def api() -> WoltApi:
-    """Return an API client containing only sanitized credentials."""
+class FakeResponse:
+    """Minimal asynchronous response implementing the API client's contract."""
+
+    def __init__(self, status: int, payload: Any = None) -> None:
+        self.status = status
+        self._payload = payload
+
+    async def json(self) -> Any:
+        if isinstance(self._payload, BaseException):
+            raise self._payload
+        return self._payload
+
+
+class FakeRequestContext:
+    """Minimal aiohttp request context manager."""
+
+    def __init__(self, response: FakeResponse | BaseException) -> None:
+        self._response = response
+
+    async def __aenter__(self) -> FakeResponse:
+        if isinstance(self._response, BaseException):
+            raise self._response
+        return self._response
+
+    async def __aexit__(self, *_args: Any) -> None:
+        return None
+
+
+class FakeSession:
+    """Queue deterministic responses and record requests without network access."""
+
+    def __init__(self, *responses: FakeResponse | BaseException) -> None:
+        self._responses = deque(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: dict[str, str],
+        data: dict[str, str] | None = None,
+    ) -> FakeRequestContext:
+        self.calls.append(
+            {
+                "method": method,
+                "url": url,
+                "headers": dict(headers),
+                "data": data,
+            }
+        )
+        return FakeRequestContext(self._responses.popleft())
+
+    def post(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str],
+        data: dict[str, str],
+    ) -> FakeRequestContext:
+        return self.request("POST", url, headers=headers, data=data)
+
+
+def make_api(session: FakeSession, session_id: str | None = "test-session") -> WoltApi:
+    """Create an API client containing only synthetic credentials."""
     return WoltApi(
-        AsyncMock(spec=aiohttp.ClientSession),
-        "sanitized-session-id",
-        "sanitized-access-token",
-        "sanitized-refresh-token",
+        session,  # type: ignore[arg-type]
+        session_id,
+        "test-access-token",
+        "test-refresh-token",
     )
 
 
-@pytest.fixture
-def load_json_fixture() -> Callable[[str], Any]:
-    """Load a sanitized Wolt response fixture."""
+async def test_active_orders_success_uses_current_token_first() -> None:
+    """Use a valid access token without refreshing it preemptively."""
+    payload = {
+        "orders": [
+            {
+                "purchase_id": "purchase-001",
+                "telemetry": {"order_status_type": "IN_PROGRESS"},
+            }
+        ]
+    }
+    session = FakeSession(FakeResponse(200, payload))
 
-    def _load(name: str) -> Any:
-        return json.loads((Path(__file__).parent / "fixtures" / name).read_text())
+    assert await make_api(session).fetch_active_orders() == payload["orders"]
+    assert len(session.calls) == 1
+    assert session.calls[0]["url"] == ACTIVE_ORDERS_URL
+    assert session.calls[0]["headers"]["authorization"] == ("Bearer test-access-token")
+    assert session.calls[0]["headers"]["w-wolt-session-id"] == "test-session"
 
-    return _load
+
+async def test_active_orders_excludes_completed_history() -> None:
+    """Do not create entities for completed orders returned by the orders page."""
+    active = {
+        "purchase_id": "purchase-active",
+        "telemetry": {"order_status_type": "IN_PROGRESS"},
+    }
+    completed = {
+        "purchase_id": "purchase-complete",
+        "telemetry": {"order_status_type": "DELIVERED"},
+    }
+    session = FakeSession(FakeResponse(200, {"orders": [active, completed]}))
+
+    assert await make_api(session).fetch_active_orders() == [active]
 
 
 @pytest.mark.parametrize(
-    ("fixture_name", "expected"),
+    ("method_name", "payload", "args"),
     [
+        ("fetch_active_orders", {"orders": {"unexpected": "shape"}}, ()),
         (
-            "active_orders.json",
-            [
-                {
-                    "purchase_id": "sanitized-purchase-001",
-                    "status": {"value": "In progress"},
-                    "telemetry": {"order_status_type": "IN_PROGRESS"},
-                    "call_to_action": {"link": "ORDER_TRACKING"},
-                    "venue": {"name": "Sanitized Test Venue"},
-                }
-            ],
+            "fetch_order_details",
+            {"order_details": "unexpected-shape"},
+            ("purchase-001",),
         ),
-        ("empty_orders.json", []),
-        ("malformed_orders.json", []),
+        ("fetch_venue_details", {"venue": ["unexpected-shape"]}, ("venue",)),
     ],
 )
-async def test_active_order_payload_contract(
-    api: WoltApi,
-    load_json_fixture: Callable[[str], Any],
-    fixture_name: str,
-    expected: list[dict[str, str]],
+async def test_malformed_payloads_raise_typed_exception(
+    method_name: str,
+    payload: dict[str, Any],
+    args: tuple[str, ...],
 ) -> None:
-    """Accept order lists and reject incompatible response shapes safely."""
-    api._request = AsyncMock(return_value=load_json_fixture(fixture_name))
+    """Report incompatible endpoint payloads instead of silently accepting them."""
+    api = make_api(FakeSession(FakeResponse(200, payload)))
 
-    assert await api.fetch_active_orders() == expected
+    with pytest.raises(WoltInvalidPayloadError):
+        await getattr(api, method_name)(*args)
 
 
-async def test_detail_payload_contracts(
-    api: WoltApi,
-    load_json_fixture: Callable[[str], Any],
-) -> None:
-    """Reject malformed order and venue payloads without raising."""
-    api._request = AsyncMock(
-        return_value=load_json_fixture("malformed_order_details.json")
+async def test_malformed_json_raises_typed_payload_exception() -> None:
+    """Translate JSON decoding failures from an otherwise successful response."""
+    api = make_api(FakeSession(FakeResponse(200, ValueError("malformed JSON"))))
+
+    with pytest.raises(WoltInvalidPayloadError):
+        await api.fetch_active_orders()
+
+
+async def test_unauthorized_request_refreshes_persists_and_retries_once() -> None:
+    """Refresh only after 401, expose rotation, notify persistence, and retry once."""
+    rotated = ("next-access-token", "next-refresh-token")
+    session = FakeSession(
+        FakeResponse(401),
+        FakeResponse(
+            200,
+            {"access_token": rotated[0], "refresh_token": rotated[1]},
+        ),
+        FakeResponse(
+            200,
+            {
+                "orders": [
+                    {
+                        "purchase_id": "purchase-001",
+                        "telemetry": {"order_status_type": "IN_PROGRESS"},
+                    }
+                ]
+            },
+        ),
     )
-    assert await api.fetch_order_details("sanitized-order-001") is None
+    persisted: list[tuple[str, str]] = []
 
-    api._request = AsyncMock(return_value=load_json_fixture("malformed_venue.json"))
-    assert await api.fetch_venue_details("sanitized-venue") is None
+    async def persist_tokens(access_token: str, refresh_token: str) -> None:
+        persisted.append((access_token, refresh_token))
 
+    api = WoltApi(
+        session,  # type: ignore[arg-type]
+        "test-session",
+        "test-access-token",
+        "test-refresh-token",
+        token_update_callback=persist_tokens,
+    )
 
-async def test_authenticated_request_uses_current_access_token_without_refresh(
-    hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
-    load_json_fixture: Callable[[str], Any],
-) -> None:
-    """Avoid rotating a valid Wolt access token before every request."""
-    aioclient_mock.get(
+    assert await api.fetch_active_orders() == [
+        {
+            "purchase_id": "purchase-001",
+            "telemetry": {"order_status_type": "IN_PROGRESS"},
+        }
+    ]
+    assert [call["url"] for call in session.calls] == [
         ACTIVE_ORDERS_URL,
-        json=load_json_fixture("active_orders.json"),
-    )
-    api = WoltApi(
-        async_get_clientsession(hass),
-        "sanitized-session-id",
-        "sanitized-access-token",
-        "sanitized-refresh-token",
-    )
-
-    orders = await api.fetch_active_orders()
-
-    assert orders[0]["purchase_id"] == "sanitized-purchase-001"
-    assert aioclient_mock.call_count == 1
-    orders_call = aioclient_mock.mock_calls[0]
-    assert orders_call[3]["authorization"] == "Bearer sanitized-access-token"
-    assert orders_call[3]["w-wolt-session-id"] == "sanitized-session-id"
-
-
-async def test_unauthorized_request_refreshes_persists_and_retries_once(
-    hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
-    load_json_fixture: Callable[[str], Any],
-) -> None:
-    """Use Wolt's current refresh flow and persist rotated credentials."""
-    from pytest_homeassistant_custom_component.common import MockConfigEntry
-
-    from custom_components.wait_for_wolt.const import DOMAIN
-
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            "session_id": "sanitized-session-id",
-            "bearer_token": "sanitized-access-token",
-            "refresh_token": "sanitized-refresh-token",
-        },
-    )
-    entry.add_to_hass(hass)
-    orders_response = aioclient_mock.request("get", ACTIVE_ORDERS_URL, status=401)
-
-    async def refresh_then_allow_retry(_method: Any, _url: Any, _data: Any) -> Any:
-        orders_response.status = 200
-        orders_response._response = json.dumps(
-            load_json_fixture("active_orders.json")
-        ).encode()
-        return refresh_response
-
-    refresh_response = aioclient_mock.request(
-        "post",
         REFRESH_URL,
-        json=load_json_fixture("token_refresh.json"),
-        side_effect=refresh_then_allow_retry,
-    )
-    api = WoltApi(
-        async_get_clientsession(hass),
-        "sanitized-session-id",
-        "sanitized-access-token",
-        "sanitized-refresh-token",
-        hass=hass,
-        entry=entry,
-    )
-
-    orders = await api.fetch_active_orders()
-
-    assert orders[0]["purchase_id"] == "sanitized-purchase-001"
-    assert aioclient_mock.call_count == 3
-    first_order_call, refresh_call, retry_call = aioclient_mock.mock_calls
-    assert first_order_call[3]["authorization"] == "Bearer sanitized-access-token"
-    assert refresh_call[2] == {
+        ACTIVE_ORDERS_URL,
+    ]
+    assert session.calls[1]["method"] == "POST"
+    assert session.calls[1]["data"] == {
         "grant_type": "refresh_token",
-        "refresh_token": "sanitized-refresh-token",
+        "refresh_token": "test-refresh-token",
     }
-    assert retry_call[3]["authorization"] == "Bearer sanitized-access-token-next"
-    assert entry.data["bearer_token"] == "sanitized-access-token-next"
-    assert entry.data["refresh_token"] == "sanitized-refresh-token-next"
+    assert session.calls[2]["headers"]["authorization"] == ("Bearer next-access-token")
+    assert api.access_token == rotated[0]
+    assert api.refresh_token == rotated[1]
+    assert persisted == [rotated]
 
 
-async def test_authentication_failure_stops_order_request(
-    hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
-    load_json_fixture: Callable[[str], Any],
-    caplog: pytest.LogCaptureFixture,
+async def test_concurrent_unauthorized_requests_share_one_token_refresh() -> None:
+    """Serialize concurrent 401 recovery when refresh tokens rotate once."""
+    api = make_api(FakeSession())
+    both_initial_requests_started = asyncio.Event()
+    initial_requests = 0
+    refreshes = 0
+
+    async def perform_request(
+        _method: str,
+        url: str,
+        *,
+        authenticated: bool,
+        data: dict[str, str] | None = None,
+    ) -> Any:
+        nonlocal initial_requests
+        del data
+        if (
+            url == ACTIVE_ORDERS_URL
+            and authenticated
+            and api.access_token == "test-access-token"
+        ):
+            initial_requests += 1
+            if initial_requests == 2:
+                both_initial_requests_started.set()
+            await both_initial_requests_started.wait()
+            raise WoltAuthenticationError("expired", status=401)
+        return {"orders": []}
+
+    async def refresh_access_token() -> None:
+        nonlocal refreshes
+        refreshes += 1
+        api._access_token = "next-access-token"
+
+    api._perform_request = perform_request  # type: ignore[method-assign]
+    api._refresh_access_token = refresh_access_token  # type: ignore[method-assign]
+
+    first, second = await asyncio.gather(
+        api.fetch_active_orders(), api.fetch_active_orders()
+    )
+
+    assert first == second == []
+    assert initial_requests == 2
+    assert refreshes == 1
+
+
+@pytest.mark.parametrize("failed_status", [400, 401, 403])
+async def test_authentication_failure_raises_without_looping(
+    failed_status: int,
 ) -> None:
-    """Retry authentication once, then stop instead of looping with stale credentials."""
-    aioclient_mock.get(ACTIVE_ORDERS_URL, status=401)
-    aioclient_mock.post(
-        REFRESH_URL,
-        status=401,
-        json=load_json_fixture("auth_failure.json"),
-    )
-    api = WoltApi(
-        async_get_clientsession(hass),
-        "sanitized-session-id",
-        "sanitized-access-token",
-        "sanitized-refresh-token",
+    """Surface refresh rejection as typed authentication failure."""
+    session = FakeSession(
+        FakeResponse(401), FakeResponse(failed_status, {"error": "no"})
     )
 
-    assert await api.fetch_active_orders() == []
-    assert aioclient_mock.call_count == 2
-    assert "Token refresh failed" in caplog.text
-    assert "sanitized-refresh-token" not in caplog.text
+    with pytest.raises(WoltAuthenticationError):
+        await make_api(session).fetch_active_orders()
+
+    assert len(session.calls) == 2
 
 
-async def test_authenticated_request_omits_missing_session_header(
-    hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
-    load_json_fixture: Callable[[str], Any],
+async def test_second_unauthorized_response_raises_without_refresh_loop() -> None:
+    """Retry the authenticated endpoint only once after successful refresh."""
+    session = FakeSession(
+        FakeResponse(401),
+        FakeResponse(200, {"access_token": "next-access-token"}),
+        FakeResponse(401),
+    )
+
+    with pytest.raises(WoltAuthenticationError):
+        await make_api(session).fetch_active_orders()
+
+    assert len(session.calls) == 3
+
+
+@pytest.mark.parametrize("session_id", [None, ""])
+async def test_authenticated_request_omits_optional_session_header(
+    session_id: str | None,
 ) -> None:
-    """Support Wolt accounts that do not expose the analytics session cookie."""
-    aioclient_mock.get(
-        ACTIVE_ORDERS_URL,
-        json=load_json_fixture("active_orders.json"),
+    """Allow accounts without Wolt's optional analytics session identifier."""
+    session = FakeSession(FakeResponse(200, {"orders": []}))
+
+    assert await make_api(session, session_id).fetch_active_orders() == []
+    assert "w-wolt-session-id" not in session.calls[0]["headers"]
+
+
+async def test_public_venue_request_sends_no_account_headers() -> None:
+    """Never leak account credentials to the public venue endpoint."""
+    session = FakeSession(FakeResponse(200, {"venue": {"online": True}}))
+
+    result = await make_api(session).fetch_venue_details("test-venue")
+
+    assert result == {"venue": {"online": True}}
+    assert session.calls[0]["url"] == VENUE_CONTENT_URL.format("test-venue")
+    assert "authorization" not in session.calls[0]["headers"]
+    assert "w-wolt-session-id" not in session.calls[0]["headers"]
+
+
+async def test_order_details_uses_rich_purchase_tracking_endpoint() -> None:
+    """Fetch rich tracking details by purchase ID from restaurant-api."""
+    session = FakeSession(FakeResponse(200, {"order_details": {"status": "delivery"}}))
+
+    assert await make_api(session).fetch_order_details("purchase-001") == {
+        "status": "delivery"
+    }
+    assert session.calls[0]["url"] == ORDER_DETAILS_URL.format("purchase-001")
+    assert session.calls[0]["url"] == (
+        "https://restaurant-api.wolt.com/v2/order_details/purchase_tracking"
+        "?purchase_id=purchase-001"
     )
-    api = WoltApi(
-        async_get_clientsession(hass),
-        "",
-        "sanitized-access-token",
-        "sanitized-refresh-token",
+
+
+async def test_order_details_accepts_legacy_list_shape() -> None:
+    """Keep compatibility with the earlier sanitized tracking fixture shape."""
+    session = FakeSession(
+        FakeResponse(200, {"order_details": [{"status": "delivery"}]})
     )
 
-    assert await api.fetch_active_orders()
-    headers = aioclient_mock.mock_calls[0][3]
-    assert "w-wolt-session-id" not in headers
+    assert await make_api(session).fetch_order_details("purchase-001") == {
+        "status": "delivery"
+    }
 
 
-async def test_public_venue_request_sends_no_account_headers(
-    hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
-    load_json_fixture: Callable[[str], Any],
+@pytest.mark.parametrize(
+    ("response", "exception_type"),
+    [
+        (TimeoutError(), WoltConnectionError),
+        (aiohttp.ClientConnectionError(), WoltConnectionError),
+        (FakeResponse(429), WoltRateLimitError),
+    ],
+)
+async def test_transport_and_rate_limit_failures_are_typed(
+    response: FakeResponse | BaseException,
+    exception_type: type[Exception],
 ) -> None:
-    """Keep account credentials off the public venue endpoint."""
-    url = VENUE_CONTENT_URL.format("sanitized-venue")
-    aioclient_mock.get(url, json=load_json_fixture("venue_open.json"))
-    api = WoltApi(
-        async_get_clientsession(hass),
-        "sanitized-session-id",
-        "sanitized-access-token",
-        "sanitized-refresh-token",
-    )
-
-    assert await api.fetch_venue_details("sanitized-venue") is not None
-    assert aioclient_mock.call_count == 1
-    headers = aioclient_mock.mock_calls[0][3]
-    assert "authorization" not in headers
-    assert "w-wolt-session-id" not in headers
+    """Distinguish retryable connectivity and rate-limit failures."""
+    with pytest.raises(exception_type):
+        await make_api(FakeSession(response)).fetch_active_orders()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,10 +1,13 @@
 """Tests for UI setup and options updates."""
 
-from homeassistant.config_entries import SOURCE_USER
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.wait_for_wolt import async_reload_entry
 from custom_components.wait_for_wolt.const import (
     CONF_BEARER_TOKEN,
     CONF_REFRESH_TOKEN,
@@ -67,6 +70,29 @@ async def test_user_flow_allows_missing_analytics_session(
     assert result["data"][CONF_SESSION_ID] == ""
 
 
+async def test_legacy_yaml_import_creates_one_durable_entry(
+    hass: HomeAssistant,
+) -> None:
+    """Import YAML once so future refresh-token rotations persist in entry data."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data=ENTRY_DATA,
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Sanitized Wolt"
+    assert result["data"][CONF_REFRESH_TOKEN] == "sanitized-refresh-token"
+
+    duplicate = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data=ENTRY_DATA,
+    )
+    assert duplicate["type"] is FlowResultType.ABORT
+    assert duplicate["reason"] == "already_configured"
+
+
 async def test_options_update_credentials_venues_and_reload(
     hass: HomeAssistant,
 ) -> None:
@@ -95,3 +121,35 @@ async def test_options_update_credentials_venues_and_reload(
         "sanitized-venue",
         "second-sanitized-venue",
     ]
+
+
+async def test_credential_only_options_update_reloads_running_entry(
+    hass: HomeAssistant,
+) -> None:
+    """Reload when credentials change but the venue options stay identical."""
+    options = {CONF_VENUE_IDS: ["sanitized-venue"]}
+    entry = MockConfigEntry(domain=DOMAIN, data=ENTRY_DATA, options=options)
+    entry.add_to_hass(hass)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        "data": dict(entry.data),
+        "options": dict(entry.options),
+    }
+    entry.add_update_listener(async_reload_entry)
+
+    with patch.object(
+        hass.config_entries, "async_reload", AsyncMock(return_value=True)
+    ) as reload_entry:
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                CONF_SESSION_ID: "sanitized-session-id-next",
+                CONF_BEARER_TOKEN: "sanitized-access-token-next",
+                CONF_REFRESH_TOKEN: "sanitized-refresh-token-next",
+                CONF_VENUE_IDS: "sanitized-venue",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    reload_entry.assert_awaited_once_with(entry.entry_id)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -52,10 +52,29 @@ async def test_config_entry_setup_and_unload_cancel_polling(
         with patch.object(
             hass.config_entries, "async_reload", AsyncMock(return_value=True)
         ) as reload_entry:
+            # A user-supplied credential edit must reload the running client.
             hass.config_entries.async_update_entry(
                 entry,
-                data={**entry.data, CONF_BEARER_TOKEN: "rotated-access-token"},
+                data={**entry.data, CONF_BEARER_TOKEN: "edited-access-token"},
             )
+            await hass.async_block_till_done()
+            reload_entry.assert_awaited_once_with(entry.entry_id)
+
+            # Simulate the completed reload, then a client-driven token rotation.
+            # The callback updates the runtime snapshot before entry persistence,
+            # so this internal update must not start a reload loop.
+            reload_entry.reset_mock()
+            hass.data[DOMAIN][entry.entry_id] = {
+                "data": dict(entry.data),
+                "options": dict(entry.options),
+            }
+            rotated_data = {
+                **entry.data,
+                CONF_BEARER_TOKEN: "rotated-access-token",
+                CONF_REFRESH_TOKEN: "rotated-refresh-token",
+            }
+            hass.data[DOMAIN][entry.entry_id]["data"] = dict(rotated_data)
+            hass.config_entries.async_update_entry(entry, data=rotated_data)
             await hass.async_block_till_done()
             reload_entry.assert_not_awaited()
 
@@ -64,7 +83,7 @@ async def test_config_entry_setup_and_unload_cancel_polling(
                 options={CONF_VENUE_IDS: ["second-sanitized-venue"]},
             )
             await hass.async_block_till_done()
-        reload_entry.assert_awaited_once_with(entry.entry_id)
+            reload_entry.assert_awaited_once_with(entry.entry_id)
 
         assert await hass.config_entries.async_unload(entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -6,18 +6,55 @@ from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from homeassistant.config_entries import SOURCE_IMPORT
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
 
+from custom_components.wait_for_wolt.api import WoltApi, WoltConnectionError
+from custom_components.wait_for_wolt.const import (
+    CONF_BEARER_TOKEN,
+    CONF_REFRESH_TOKEN,
+    CONF_SESSION_ID,
+    CONF_VENUE_IDS,
+    DOMAIN,
+)
 from custom_components.wait_for_wolt.sensor import (
-    WoltApi,
     WoltOrderSensor,
     WoltVenueSensor,
     _setup_sensors,
+    async_setup_platform,
 )
 
 
 def load_json_fixture(name: str) -> Any:
     """Load a sanitized fixture."""
     return json.loads((Path(__file__).parent / "fixtures" / name).read_text())
+
+
+async def test_legacy_yaml_platform_starts_config_entry_import(
+    hass: HomeAssistant,
+) -> None:
+    """Migrate YAML credentials instead of running with non-durable rotation."""
+    config = {
+        CONF_NAME: "Sanitized Wolt",
+        CONF_SESSION_ID: "sanitized-session-id",
+        CONF_BEARER_TOKEN: "sanitized-access-token",
+        CONF_REFRESH_TOKEN: "sanitized-refresh-token",
+        CONF_VENUE_IDS: ["sanitized-venue"],
+    }
+
+    with patch.object(
+        hass.config_entries.flow,
+        "async_init",
+        AsyncMock(return_value={}),
+    ) as import_flow:
+        await async_setup_platform(hass, config, Mock())
+
+    import_flow.assert_awaited_once_with(
+        DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data=config,
+    )
 
 
 async def test_initial_active_order_is_added_once() -> None:
@@ -98,6 +135,51 @@ async def test_polling_discovers_only_new_orders_after_empty_response() -> None:
     assert [entity.order_id for entity in entities] == ["sanitized-purchase-001"]
 
 
+async def test_config_entry_persists_rotated_tokens_via_api_callback() -> None:
+    """Keep Home Assistant persistence outside the extracted API layer."""
+    hass = Mock()
+    entry = Mock(
+        data={
+            "session_id": "test-session",
+            "bearer_token": "old-access-token",
+            "refresh_token": "old-refresh-token",
+            "preserved": True,
+        }
+    )
+    api = Mock(spec=WoltApi)
+    api.fetch_active_orders = AsyncMock(return_value=[])
+
+    with (
+        patch("custom_components.wait_for_wolt.sensor.async_get_clientsession"),
+        patch(
+            "custom_components.wait_for_wolt.sensor.WoltApi", return_value=api
+        ) as api_cls,
+        patch("custom_components.wait_for_wolt.sensor.async_track_time_interval"),
+    ):
+        await _setup_sensors(
+            hass,
+            Mock(),
+            "Wolt",
+            "test-session",
+            "old-access-token",
+            "old-refresh-token",
+            entry=entry,
+        )
+
+    callback = api_cls.call_args.kwargs["token_update_callback"]
+    callback("new-access-token", "new-refresh-token")
+
+    hass.config_entries.async_update_entry.assert_called_once_with(
+        entry,
+        data={
+            "session_id": "test-session",
+            "bearer_token": "new-access-token",
+            "refresh_token": "new-refresh-token",
+            "preserved": True,
+        },
+    )
+
+
 async def test_order_sensor_state_attributes_and_availability() -> None:
     """Expose a sanitized order response and become unavailable on API failure."""
     api = AsyncMock(spec=WoltApi)
@@ -123,10 +205,25 @@ async def test_order_sensor_state_attributes_and_availability() -> None:
         "items": ["Sanitized item"],
     }
 
-    api.fetch_order_details.return_value = None
+    api.fetch_order_details.side_effect = WoltConnectionError("offline")
     await sensor.async_update()
 
     assert not sensor.available
+
+
+async def test_order_sensor_normalizes_current_status_object() -> None:
+    """Expose the current purchase-tracking status object as a scalar state."""
+    api = AsyncMock(spec=WoltApi)
+    api.fetch_order_details.return_value = {
+        "status": {"value": "In progress"},
+        "venue_name": "Sanitized Test Venue",
+    }
+    sensor = WoltOrderSensor(api, "sanitized-order-001", "Wolt order")
+
+    await sensor.async_update()
+
+    assert sensor.available
+    assert sensor.native_value == "In progress"
 
 
 @pytest.mark.parametrize(
@@ -148,7 +245,7 @@ async def test_venue_sensor_state_and_availability(
     assert sensor.native_value == expected_state
     assert sensor.available
 
-    api.fetch_venue_details.return_value = None
+    api.fetch_venue_details.side_effect = WoltConnectionError("offline")
     await sensor.async_update()
 
     assert not sensor.available


### PR DESCRIPTION
## Summary

This is the first canonical-core refactor and a follow-up to the immutable review of #15.

- extract Wolt HTTP/auth logic from `sensor.py` into a Home Assistant-independent `api.py`
- add typed authentication, connectivity, rate-limit, and payload failures
- use the current access token first; after `401`, serialize refresh-token rotation and retry once
- persist rotated credentials without triggering config-entry reload loops
- reload correctly when a user edits credentials without changing venue options
- use the current rich purchase-tracking endpoint and accept its current object shape plus the legacy sanitized list shape
- filter completed order history before creating entities
- omit account headers from public venue requests
- import legacy YAML once into a durable config entry, then deprecate YAML as a runtime credential source
- align the declared minimum Home Assistant version with the tested 2026.7 environment

This resolves every blocker from the post-merge immutable review of #15: credential-only reloads, YAML refresh-token durability, concurrent refresh races, and malformed JSON handling.

## Verification

Exact head: `67ecaa7384c2d2dd4f7a0266aeda01feebbc45ab`

- `git diff --check`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest` → **34 passed**
- Hassfest container → **1 integration, 0 invalid**
- `detect-secrets` with caches/lock excluded → **0 findings**
- all tests and fixtures are synthetic; no real Wolt or Home Assistant credentials were used

## Scope

This advances #20 but does not close it: the shared `DataUpdateCoordinator`, setup retry/auth semantics, and coordinator-driven entities remain the next core change.
