### PR TITLE
refactor: coordinate Wolt polling and reauthentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   connectivity, rate-limit, and payload errors.
 - Rich purchase-tracking endpoint support with current and legacy response-shape
   compatibility.
+- A shared `DataUpdateCoordinator` with dynamic order discovery and Home
+  Assistant reauthentication support.
+- Privacy-preserving diagnostics that expose operational counts without order,
+  courier, venue, account-name, or credential values.
 
 ### Changed
 
@@ -26,6 +30,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   deprecated as a runtime credential source.
 - The minimum supported Home Assistant version is now 2026.7.0, matching the
   tested Python and Home Assistant environment.
+- Authenticated polling adapts from five minutes while idle to 30 seconds while
+  an order is active; venue polling uses a conservative five-minute interval.
+- Credential inputs are password-masked, and options no longer prefill saved
+  access or refresh tokens.
 
 ### Fixed
 
@@ -34,6 +42,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   of racing rotating refresh tokens.
 - Malformed JSON responses become typed payload errors instead of escaping the
   integration update path.
+- Optional rich tracking failures now preserve the usable order summary instead
+  of making every order entity unavailable.
+- Venue sensors now preserve an explicit closed status even when broader venue
+  metadata still reports the venue online.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -74,12 +74,21 @@ imported config entry becomes the authoritative credential store.
 ID. Enter one ID per line or list entry. When configuring from the UI, type each
 ID on a new line.
 
+The integration masks credential fields in setup, options, and reauthentication
+forms. In **Configure**, leave the access and refresh token fields blank to keep
+their saved values. If Wolt rejects both saved credentials, Home Assistant opens
+a reauthentication flow for replacement tokens.
+
 ## How it works
 - The integration refreshes the bearer token automatically.
-- Every minute it polls Wolt for your active orders.
+- One shared coordinator polls every 30 seconds while an order is active and every
+  five minutes while idle. Each authenticated endpoint is fetched at most once per
+  cycle, and optional rich tracking failures fall back to the order summary.
 - A sensor entity is created for each order that is in progress. The sensor state reflects the current order status and attributes include the delivery estimate, venue and items ordered.
 - New orders placed while Home Assistant is running are discovered automatically within the polling interval.
-- If you configure `venue_ids`, sensors for each venue report whether it is open and expose delivery price and estimates when available.
+- If you configure `venue_ids`, sensors poll the public venue endpoint every five
+  minutes, report whether it is open, and expose delivery price and estimates when
+  available.
 
 ## Limitations
 - This is an unofficial integration and is not affiliated with or endorsed by Wolt.

--- a/custom_components/wait_for_wolt/__init__.py
+++ b/custom_components/wait_for_wolt/__init__.py
@@ -6,9 +6,17 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DOMAIN
+from .api import WoltApi
+from .const import (
+    CONF_BEARER_TOKEN,
+    CONF_REFRESH_TOKEN,
+    CONF_SESSION_ID,
+    DOMAIN,
+)
+from .coordinator import WoltDataUpdateCoordinator, WoltRuntimeData
 
 PLATFORMS = [Platform.SENSOR]
 CONFIG_SCHEMA = cv.platform_only_config_schema(DOMAIN)
@@ -25,10 +33,34 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Forward config entry setup to the sensor platform."""
+    """Create the shared client/coordinator and set up entry platforms."""
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = _entry_snapshot(entry)
-    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
+
+    def persist_tokens(access_token: str, refresh_token: str) -> None:
+        """Persist Wolt credential rotation without reloading the runtime."""
+        updated_data = {
+            **entry.data,
+            CONF_BEARER_TOKEN: access_token,
+            CONF_REFRESH_TOKEN: refresh_token,
+        }
+        runtime_snapshot = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+        if isinstance(runtime_snapshot, dict):
+            runtime_snapshot["data"] = dict(updated_data)
+            runtime_snapshot["options"] = dict(entry.options)
+        hass.config_entries.async_update_entry(entry, data=updated_data)
+
+    api = WoltApi(
+        async_get_clientsession(hass),
+        entry.data.get(CONF_SESSION_ID, ""),
+        entry.data[CONF_BEARER_TOKEN],
+        entry.data[CONF_REFRESH_TOKEN],
+        token_update_callback=persist_tokens,
+    )
+    coordinator = WoltDataUpdateCoordinator(hass, entry, api)
+    entry.runtime_data = WoltRuntimeData(api, coordinator)
     try:
+        await coordinator.async_config_entry_first_refresh()
+        entry.async_on_unload(entry.add_update_listener(async_reload_entry))
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     except Exception:
         hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)

--- a/custom_components/wait_for_wolt/api.py
+++ b/custom_components/wait_for_wolt/api.py
@@ -32,7 +32,7 @@ FINAL_ORDER_STATUS_TYPES = {
 }
 
 
-def _active_order(order: dict[str, Any]) -> bool:
+def is_active_order(order: dict[str, Any]) -> bool:
     """Return whether an order-list item represents a trackable active order."""
     telemetry = order.get("telemetry")
     status_type = (
@@ -235,16 +235,16 @@ class WoltApi:
                 await self._refresh_access_token()
         return await self._perform_request(method, url, authenticated=True)
 
-    async def fetch_active_orders(self) -> list[dict[str, Any]]:
-        """Fetch the account's active orders."""
+    async def fetch_orders(self) -> list[dict[str, Any]]:
+        """Fetch the account's order page, including recent completed orders."""
         data = await self._request("GET", ACTIVE_ORDERS_URL)
         if not isinstance(data, dict) or not isinstance(data.get("orders"), list):
-            raise WoltInvalidPayloadError("Wolt active orders payload is invalid")
-        return [
-            order
-            for order in data["orders"]
-            if isinstance(order, dict) and _active_order(order)
-        ]
+            raise WoltInvalidPayloadError("Wolt orders payload is invalid")
+        return [order for order in data["orders"] if isinstance(order, dict)]
+
+    async def fetch_active_orders(self) -> list[dict[str, Any]]:
+        """Fetch only trackable active orders from the account's order page."""
+        return [order for order in await self.fetch_orders() if is_active_order(order)]
 
     async def fetch_order_details(self, purchase_id: str) -> dict[str, Any]:
         """Fetch rich purchase-tracking details for an order."""

--- a/custom_components/wait_for_wolt/config_flow.py
+++ b/custom_components/wait_for_wolt/config_flow.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_NAME
-from homeassistant.helpers.selector import TextSelector
+from homeassistant.helpers.selector import (
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+)
 
 from .const import (
     CONF_BEARER_TOKEN,
@@ -14,6 +18,9 @@ from .const import (
     DOMAIN,
 )
 
+SECRET_SELECTOR = TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD))
+REQUIRED_SECRET = vol.All(SECRET_SELECTOR, vol.Length(min=1))
+
 
 class WoltConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Wait for Wolt."""
@@ -22,9 +29,9 @@ class WoltConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     DATA_SCHEMA = vol.Schema(
         {
-            vol.Optional(CONF_SESSION_ID, default=""): str,
-            vol.Required(CONF_BEARER_TOKEN): str,
-            vol.Required(CONF_REFRESH_TOKEN): str,
+            vol.Optional(CONF_SESSION_ID, default=""): SECRET_SELECTOR,
+            vol.Required(CONF_BEARER_TOKEN): REQUIRED_SECRET,
+            vol.Required(CONF_REFRESH_TOKEN): REQUIRED_SECRET,
             vol.Optional(CONF_VENUE_IDS, default=""): TextSelector({"multiline": True}),
             vol.Optional(CONF_NAME, default=DEFAULT_NAME): str,
         }
@@ -62,6 +69,33 @@ class WoltConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data=data,
         )
 
+    async def async_step_reauth(self, entry_data):
+        """Start reauthentication after the coordinator rejects credentials."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(self, user_input=None):
+        """Replace rejected credentials and reload the config entry."""
+        entry = self._get_reauth_entry()
+        if user_input is not None:
+            return self.async_update_reload_and_abort(
+                entry,
+                data_updates={
+                    CONF_SESSION_ID: user_input.get(CONF_SESSION_ID)
+                    or entry.data.get(CONF_SESSION_ID, ""),
+                    CONF_BEARER_TOKEN: user_input[CONF_BEARER_TOKEN],
+                    CONF_REFRESH_TOKEN: user_input[CONF_REFRESH_TOKEN],
+                },
+            )
+
+        schema = vol.Schema(
+            {
+                vol.Optional(CONF_SESSION_ID, default=""): SECRET_SELECTOR,
+                vol.Required(CONF_BEARER_TOKEN): REQUIRED_SECRET,
+                vol.Required(CONF_REFRESH_TOKEN): REQUIRED_SECRET,
+            }
+        )
+        return self.async_show_form(step_id="reauth_confirm", data_schema=schema)
+
     @staticmethod
     def async_get_options_flow(config_entry):
         return WoltOptionsFlowHandler(config_entry)
@@ -84,8 +118,10 @@ class WoltOptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
                 data={
                     **self.config_entry.data,
                     CONF_SESSION_ID: user_input.get(CONF_SESSION_ID, ""),
-                    CONF_BEARER_TOKEN: user_input[CONF_BEARER_TOKEN],
-                    CONF_REFRESH_TOKEN: user_input[CONF_REFRESH_TOKEN],
+                    CONF_BEARER_TOKEN: user_input.get(CONF_BEARER_TOKEN)
+                    or self.config_entry.data[CONF_BEARER_TOKEN],
+                    CONF_REFRESH_TOKEN: user_input.get(CONF_REFRESH_TOKEN)
+                    or self.config_entry.data[CONF_REFRESH_TOKEN],
                 },
                 options=options,
             )
@@ -103,16 +139,10 @@ class WoltOptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
             {
                 vol.Optional(
                     CONF_SESSION_ID,
-                    default=self.config_entry.data.get(CONF_SESSION_ID, ""),
-                ): str,
-                vol.Required(
-                    CONF_BEARER_TOKEN,
-                    default=self.config_entry.data.get(CONF_BEARER_TOKEN, ""),
-                ): str,
-                vol.Required(
-                    CONF_REFRESH_TOKEN,
-                    default=self.config_entry.data.get(CONF_REFRESH_TOKEN, ""),
-                ): str,
+                    default="",
+                ): SECRET_SELECTOR,
+                vol.Optional(CONF_BEARER_TOKEN, default=""): SECRET_SELECTOR,
+                vol.Optional(CONF_REFRESH_TOKEN, default=""): SECRET_SELECTOR,
                 vol.Optional(CONF_VENUE_IDS, default=current): TextSelector(
                     {"multiline": True}
                 ),

--- a/custom_components/wait_for_wolt/coordinator.py
+++ b/custom_components/wait_for_wolt/coordinator.py
@@ -1,0 +1,111 @@
+"""Coordinator for conservative Wolt order polling."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry, ConfigEntryAuthFailed
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .api import (
+    WoltApi,
+    WoltAuthenticationError,
+    WoltConnectionError,
+    WoltInvalidPayloadError,
+    WoltRateLimitError,
+    is_active_order,
+)
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+ACTIVE_UPDATE_INTERVAL = timedelta(seconds=30)
+IDLE_UPDATE_INTERVAL = timedelta(minutes=5)
+
+
+@dataclass(frozen=True, slots=True)
+class WoltCoordinatorData:
+    """One coherent snapshot of account orders and active-order details."""
+
+    orders: dict[str, dict[str, Any]]
+    active_order_ids: frozenset[str]
+    details: dict[str, dict[str, Any]]
+
+
+class WoltDataUpdateCoordinator(DataUpdateCoordinator[WoltCoordinatorData]):
+    """Fetch each authenticated Wolt resource once per polling cycle."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        api: WoltApi,
+    ) -> None:
+        """Initialize the coordinator at the conservative idle interval."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=entry,
+            name=DOMAIN,
+            update_interval=IDLE_UPDATE_INTERVAL,
+        )
+        self.api = api
+        self._rich_tracking_warning_logged = False
+
+    async def _async_update_data(self) -> WoltCoordinatorData:
+        """Fetch orders and details, translating failures for Home Assistant."""
+        try:
+            raw_orders = await self.api.fetch_orders()
+            orders = {
+                order_id: order
+                for order in raw_orders
+                if (order_id := self.order_id(order)) is not None
+            }
+            active_order_ids = frozenset(
+                order_id for order_id, order in orders.items() if is_active_order(order)
+            )
+            details: dict[str, dict[str, Any]] = {}
+            rich_tracking_failed = False
+            # Orders are normally singular. Keep requests sequential to avoid bursts
+            # against Wolt's unofficial consumer endpoints.
+            for order_id in sorted(active_order_ids):
+                try:
+                    details[order_id] = await self.api.fetch_order_details(order_id)
+                except WoltAuthenticationError, WoltRateLimitError:
+                    raise
+                except WoltConnectionError, WoltInvalidPayloadError:
+                    # The summary remains useful while the optional rich endpoint
+                    # is unavailable or has not populated a newly placed order.
+                    rich_tracking_failed = True
+            if rich_tracking_failed and not self._rich_tracking_warning_logged:
+                _LOGGER.warning("Rich Wolt order tracking details are unavailable")
+            self._rich_tracking_warning_logged = rich_tracking_failed
+        except WoltAuthenticationError as err:
+            raise ConfigEntryAuthFailed("Wolt authentication failed") from err
+        except WoltRateLimitError as err:
+            raise UpdateFailed("Wolt rate limit reached") from err
+        except (WoltConnectionError, WoltInvalidPayloadError) as err:
+            raise UpdateFailed("Unable to update Wolt orders") from err
+
+        self.update_interval = (
+            ACTIVE_UPDATE_INTERVAL if active_order_ids else IDLE_UPDATE_INTERVAL
+        )
+        return WoltCoordinatorData(orders, active_order_ids, details)
+
+    @staticmethod
+    def order_id(order: dict[str, Any]) -> str | None:
+        """Return Wolt's current purchase ID with legacy fallbacks."""
+        value = order.get("purchase_id") or order.get("order_id") or order.get("id")
+        return str(value) if value else None
+
+
+@dataclass(slots=True)
+class WoltRuntimeData:
+    """Runtime objects owned by one Wolt config entry."""
+
+    api: WoltApi
+    coordinator: WoltDataUpdateCoordinator

--- a/custom_components/wait_for_wolt/diagnostics.py
+++ b/custom_components/wait_for_wolt/diagnostics.py
@@ -1,0 +1,49 @@
+"""Privacy-preserving diagnostics for Wolt Order Tracker."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    CONF_BEARER_TOKEN,
+    CONF_REFRESH_TOKEN,
+    CONF_SESSION_ID,
+    CONF_VENUE_IDS,
+)
+
+TO_REDACT = {
+    CONF_NAME,
+    CONF_SESSION_ID,
+    CONF_BEARER_TOKEN,
+    CONF_REFRESH_TOKEN,
+    CONF_VENUE_IDS,
+}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+) -> dict[str, Any]:
+    """Return operational counts without order, courier, venue, or credential data."""
+    del hass
+    coordinator = entry.runtime_data.coordinator
+    data = coordinator.data
+    interval = coordinator.update_interval
+    return {
+        "entry": async_redact_data(dict(entry.data), TO_REDACT),
+        "options": async_redact_data(dict(entry.options), TO_REDACT),
+        "coordinator": {
+            "last_update_success": coordinator.last_update_success,
+            "known_order_count": len(data.orders),
+            "active_order_count": len(data.active_order_ids),
+            "rich_detail_count": len(data.details),
+            "update_interval_seconds": (
+                int(interval.total_seconds()) if interval is not None else None
+            ),
+        },
+    }

--- a/custom_components/wait_for_wolt/sensor.py
+++ b/custom_components/wait_for_wolt/sensor.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
 from datetime import timedelta
 from typing import Any
 
@@ -12,11 +11,10 @@ import voluptuous as vol
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_NAME
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .api import WoltApi, WoltApiError
 from .const import (
@@ -26,10 +24,12 @@ from .const import (
     CONF_VENUE_IDS,
     DEFAULT_NAME,
     DOMAIN,
-    UPDATE_INTERVAL,
 )
+from .coordinator import WoltDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = timedelta(minutes=5)
 
 PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend(
     {
@@ -40,79 +40,6 @@ PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     }
 )
-
-
-async def _setup_sensors(
-    hass: HomeAssistant,
-    async_add_entities: AddEntitiesCallback,
-    name: str,
-    session_id: str,
-    token: str,
-    refresh: str,
-    venues: list[str] | None = None,
-    entry: ConfigEntry | None = None,
-) -> Callable[[], None]:
-    """Create sensors and schedule updates."""
-    session = async_get_clientsession(hass)
-
-    def _persist_tokens(access_token: str, refresh_token: str) -> None:
-        if entry is None:
-            return
-        updated_data = {
-            **entry.data,
-            CONF_BEARER_TOKEN: access_token,
-            CONF_REFRESH_TOKEN: refresh_token,
-        }
-        runtime = hass.data.get(DOMAIN, {}).get(entry.entry_id)
-        if isinstance(runtime, dict):
-            runtime["data"] = dict(updated_data)
-            runtime["options"] = dict(entry.options)
-        hass.config_entries.async_update_entry(
-            entry,
-            data=updated_data,
-        )
-
-    api = WoltApi(
-        session,
-        session_id,
-        token,
-        refresh,
-        token_update_callback=_persist_tokens if entry is not None else None,
-    )
-
-    sensors: list[WoltOrderSensor] = []
-    venue_sensors: list[WoltVenueSensor] = []
-
-    if venues:
-        for slug in venues:
-            venue_sensors.append(WoltVenueSensor(api, slug, f"{name} {slug}"))
-        async_add_entities(venue_sensors, update_before_add=True)
-
-    async def _update_orders(now=None, *, update_before_add: bool = False) -> None:
-        try:
-            orders = await api.fetch_active_orders()
-        except WoltApiError as err:
-            _LOGGER.warning("Unable to fetch active Wolt orders: %s", err)
-            return
-        known = {sensor.order_id for sensor in sensors}
-        new_entities = []
-        for order in orders:
-            order_id = order.get("purchase_id") or order.get("order_id")
-            if not order_id or order_id in known:
-                continue
-            sensor = WoltOrderSensor(api, order_id, f"{name} {order_id}")
-            sensors.append(sensor)
-            new_entities.append(sensor)
-        if new_entities:
-            async_add_entities(new_entities, update_before_add=update_before_add)
-
-    await _update_orders(update_before_add=True)
-    if not sensors:
-        _LOGGER.info("No active orders found")
-
-    return async_track_time_interval(
-        hass, _update_orders, timedelta(seconds=UPDATE_INTERVAL)
-    )
 
 
 async def async_setup_platform(
@@ -145,69 +72,99 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Wolt sensors from a config entry."""
+    """Set up coordinator-backed order sensors and public venue sensors."""
     data = {**entry.data, **entry.options}
+    runtime = entry.runtime_data
+    coordinator = runtime.coordinator
+    api = runtime.api
+    name = data.get(CONF_NAME, DEFAULT_NAME)
     venues = data.get(CONF_VENUE_IDS, [])
-    cancel_interval = await _setup_sensors(
-        hass,
-        async_add_entities,
-        data.get(CONF_NAME, DEFAULT_NAME),
-        data.get(CONF_SESSION_ID, ""),
-        data[CONF_BEARER_TOKEN],
-        data[CONF_REFRESH_TOKEN],
-        venues,
-        entry,
-    )
-    entry.async_on_unload(cancel_interval)
+    if venues:
+        async_add_entities(
+            [WoltVenueSensor(api, slug, f"{name} {slug}") for slug in venues],
+            update_before_add=True,
+        )
+
+    known_order_ids: set[str] = set()
+
+    @callback
+    def async_add_new_orders() -> None:
+        new_order_ids = coordinator.data.active_order_ids - known_order_ids
+        if not new_order_ids:
+            return
+        known_order_ids.update(new_order_ids)
+        async_add_entities(
+            [
+                WoltOrderSensor(coordinator, order_id, f"{name} {order_id}")
+                for order_id in sorted(new_order_ids)
+            ]
+        )
+
+    async_add_new_orders()
+    entry.async_on_unload(coordinator.async_add_listener(async_add_new_orders))
 
 
-class WoltOrderSensor(SensorEntity):
+class WoltOrderSensor(CoordinatorEntity[WoltDataUpdateCoordinator], SensorEntity):
     """Representation of a Wolt order sensor."""
 
     _attr_attribution = "Data provided by Wolt"
 
-    def __init__(self, api: WoltApi, order_id: str, name: str) -> None:
-        self.api = api
+    _attr_icon = "mdi:package-variant"
+
+    def __init__(
+        self,
+        coordinator: WoltDataUpdateCoordinator,
+        order_id: str,
+        name: str,
+    ) -> None:
+        super().__init__(coordinator)
         self.order_id = order_id
         self._attr_name = name
         self._attr_unique_id = f"wolt_{order_id}"
-        self._attr_extra_state_attributes = {}
-        self._attr_available = False
-        self._state = None
+
+    @property
+    def available(self) -> bool:
+        """Remain available while the order exists in the shared snapshot."""
+        return super().available and self.order_id in self.coordinator.data.orders
+
+    @property
+    def _order_data(self) -> dict[str, Any]:
+        """Merge the order summary with richer active tracking details."""
+        return {
+            **self.coordinator.data.orders.get(self.order_id, {}),
+            **self.coordinator.data.details.get(self.order_id, {}),
+        }
 
     @property
     def native_value(self):
-        return self._state
-
-    async def async_update(self) -> None:
-        try:
-            details = await self.api.fetch_order_details(self.order_id)
-        except WoltApiError as err:
-            self._attr_available = False
-            _LOGGER.warning("Unable to update Wolt order %s: %s", self.order_id, err)
-            return
-        if not details:
-            self._attr_available = False
-            _LOGGER.warning("Order %s details not found", self.order_id)
-            return
-        self._attr_available = True
-        status = details.get("status")
+        """Return the normalized Wolt status as a scalar sensor state."""
+        order = self._order_data
+        status = order.get("status")
         if isinstance(status, dict):
             status = status.get("value") or status.get("text") or status.get("label")
         if status is None:
-            status = details.get("order_status_type")
-        self._state = str(status) if status is not None else None
-        items = details.get("items")
-        self._attr_extra_state_attributes = {
-            "delivery_eta": details.get("delivery_eta"),
-            "client_pre_estimate": details.get("client_pre_estimate"),
-            "venue_name": details.get("venue_name"),
-            "payment_amount": details.get("payment_amount"),
+            telemetry = order.get("telemetry")
+            status = (
+                telemetry.get("order_status_type")
+                if isinstance(telemetry, dict)
+                else order.get("order_status_type")
+            )
+        return str(status) if status is not None else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return useful, non-credential order metadata from the shared snapshot."""
+        order = self._order_data
+        items = order.get("items")
+        return {
+            "delivery_eta": order.get("delivery_eta"),
+            "client_pre_estimate": order.get("client_pre_estimate"),
+            "venue_name": order.get("venue_name"),
+            "payment_amount": order.get("payment_amount"),
             "items": [item.get("name") for item in items if isinstance(item, dict)]
             if isinstance(items, list)
             else [],
         }
-        self._attr_icon = "mdi:package-variant"
 
 
 class WoltVenueSensor(SensorEntity):
@@ -245,9 +202,11 @@ class WoltVenueSensor(SensorEntity):
         self._attr_available = True
         open_info = venue.get("delivery_open_status") or venue.get("open_status") or {}
 
-        is_open = (
-            open_info.get("is_open") or venue.get("online") or venue.get("is_open")
-        )
+        is_open = open_info.get("is_open")
+        if is_open is None:
+            is_open = venue.get("online")
+        if is_open is None:
+            is_open = venue.get("is_open")
         self._state = "open" if is_open else "closed"
 
         # Extract estimates for available delivery methods

--- a/custom_components/wait_for_wolt/strings.json
+++ b/custom_components/wait_for_wolt/strings.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "abort": {
-      "already_configured": "A Wolt account is already configured. Remove the legacy YAML block after it has been imported."
+      "already_configured": "A Wolt account is already configured. Remove the legacy YAML block after it has been imported.",
+      "reauth_successful": "Wolt credentials were updated successfully."
     },
     "step": {
       "user": {
@@ -16,12 +17,21 @@
       },
       "init": {
         "title": "Update Wolt settings",
-        "description": "Update tokens or venue IDs. The analytics session ID is optional. Venue IDs are slugs from the venue URL; separate multiple IDs by new lines.",
+        "description": "Update tokens or venue IDs. Leave access and refresh tokens blank to keep their current values. The analytics session ID is optional; leaving it blank clears it. Venue IDs are slugs from the venue URL; separate multiple IDs by new lines.",
         "data": {
           "session_id": "Session ID (optional)",
           "bearer_token": "Access Token",
           "refresh_token": "Refresh Token",
           "venue_ids": "Venue IDs"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Reconnect Wolt",
+        "description": "Wolt rejected the saved credentials. Enter a current access token and refresh token from wolt.com. The analytics session ID is optional; leave it blank to keep the saved value.",
+        "data": {
+          "session_id": "Session ID (optional)",
+          "bearer_token": "Access Token",
+          "refresh_token": "Refresh Token"
         }
       }
     }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import AsyncMock, patch
 
-from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_REAUTH, SOURCE_USER
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -121,6 +121,66 @@ async def test_options_update_credentials_venues_and_reload(
         "sanitized-venue",
         "second-sanitized-venue",
     ]
+
+
+async def test_options_blank_secret_fields_preserve_saved_tokens(
+    hass: HomeAssistant,
+) -> None:
+    """Do not expose or erase saved tokens when only venue options change."""
+    entry = MockConfigEntry(domain=DOMAIN, data=ENTRY_DATA)
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            CONF_SESSION_ID: "",
+            CONF_BEARER_TOKEN: "",
+            CONF_REFRESH_TOKEN: "",
+            CONF_VENUE_IDS: "second-sanitized-venue",
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert entry.data[CONF_SESSION_ID] == ""
+    assert entry.data[CONF_BEARER_TOKEN] == "sanitized-access-token"
+    assert entry.data[CONF_REFRESH_TOKEN] == "sanitized-refresh-token"
+
+
+async def test_reauthentication_updates_credentials_and_reloads(
+    hass: HomeAssistant,
+) -> None:
+    """Replace rejected secrets through Home Assistant's reauth flow."""
+    entry = MockConfigEntry(domain=DOMAIN, data=ENTRY_DATA)
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_REAUTH, "entry_id": entry.entry_id},
+        data=entry.data,
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    with patch.object(
+        hass.config_entries, "async_reload", AsyncMock(return_value=True)
+    ) as reload_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_SESSION_ID: "",
+                CONF_BEARER_TOKEN: "sanitized-access-token-next",
+                CONF_REFRESH_TOKEN: "sanitized-refresh-token-next",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert entry.data[CONF_SESSION_ID] == "sanitized-session-id"
+    assert entry.data[CONF_BEARER_TOKEN] == "sanitized-access-token-next"
+    assert entry.data[CONF_REFRESH_TOKEN] == "sanitized-refresh-token-next"
+    reload_entry.assert_awaited_once_with(entry.entry_id)
 
 
 async def test_credential_only_options_update_reloads_running_entry(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,179 @@
+"""Tests for shared Wolt polling and Home Assistant error semantics."""
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, call
+
+import pytest
+from homeassistant.config_entries import ConfigEntryAuthFailed
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import UpdateFailed
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.wait_for_wolt.api import (
+    WoltApi,
+    WoltAuthenticationError,
+    WoltConnectionError,
+    WoltInvalidPayloadError,
+    WoltRateLimitError,
+)
+from custom_components.wait_for_wolt.const import DOMAIN
+from custom_components.wait_for_wolt.coordinator import (
+    ACTIVE_UPDATE_INTERVAL,
+    IDLE_UPDATE_INTERVAL,
+    WoltDataUpdateCoordinator,
+)
+
+
+def make_coordinator(
+    hass: HomeAssistant,
+    api: AsyncMock,
+) -> WoltDataUpdateCoordinator:
+    """Create a coordinator with a synthetic config entry."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+    return WoltDataUpdateCoordinator(hass, entry, api)
+
+
+async def test_coordinator_fetches_one_shared_active_order_snapshot(
+    hass: HomeAssistant,
+) -> None:
+    """Fetch the order page once and details once per active order."""
+    active = {
+        "purchase_id": "purchase-active",
+        "status": {"value": "In progress"},
+        "telemetry": {"order_status_type": "IN_PROGRESS"},
+    }
+    second_active = {
+        "purchase_id": "purchase-second",
+        "status": {"value": "Preparing"},
+        "telemetry": {"order_status_type": "IN_PROGRESS"},
+    }
+    completed = {
+        "purchase_id": "purchase-complete",
+        "status": {"value": "Delivered"},
+        "telemetry": {"order_status_type": "DELIVERED"},
+    }
+    api = AsyncMock(spec=WoltApi)
+    api.fetch_orders.return_value = [active, completed, second_active]
+    api.fetch_order_details.return_value = {"status": {"value": "On the way"}}
+    coordinator = make_coordinator(hass, api)
+
+    data = await coordinator._async_update_data()
+
+    assert data.orders == {
+        "purchase-active": active,
+        "purchase-complete": completed,
+        "purchase-second": second_active,
+    }
+    assert data.active_order_ids == frozenset({"purchase-active", "purchase-second"})
+    assert data.details == {
+        "purchase-active": {"status": {"value": "On the way"}},
+        "purchase-second": {"status": {"value": "On the way"}},
+    }
+    assert coordinator.update_interval == ACTIVE_UPDATE_INTERVAL
+    api.fetch_orders.assert_awaited_once_with()
+    assert api.fetch_order_details.await_args_list == [
+        call("purchase-active"),
+        call("purchase-second"),
+    ]
+
+
+async def test_coordinator_uses_conservative_idle_interval(
+    hass: HomeAssistant,
+) -> None:
+    """Avoid rich tracking requests and poll slowly when no order is active."""
+    api = AsyncMock(spec=WoltApi)
+    api.fetch_orders.return_value = []
+    coordinator = make_coordinator(hass, api)
+
+    data = await coordinator._async_update_data()
+
+    assert data.orders == {}
+    assert data.active_order_ids == frozenset()
+    assert data.details == {}
+    assert coordinator.update_interval == IDLE_UPDATE_INTERVAL
+    api.fetch_order_details.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "error",
+    [WoltConnectionError("not ready", status=404), WoltInvalidPayloadError("changed")],
+)
+async def test_optional_tracking_failure_keeps_order_summary_available(
+    hass: HomeAssistant,
+    error: Exception,
+) -> None:
+    """Degrade to the orders page when optional rich tracking is unavailable."""
+    active = {
+        "purchase_id": "purchase-active",
+        "status": {"value": "In progress"},
+        "telemetry": {"order_status_type": "IN_PROGRESS"},
+    }
+    api = AsyncMock(spec=WoltApi)
+    api.fetch_orders.return_value = [active]
+    api.fetch_order_details.side_effect = error
+
+    data = await make_coordinator(hass, api)._async_update_data()
+
+    assert data.orders == {"purchase-active": active}
+    assert data.active_order_ids == frozenset({"purchase-active"})
+    assert data.details == {}
+
+
+async def test_optional_tracking_warning_is_not_repeated_each_active_poll(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Avoid a warning every 30 seconds during a rich-endpoint outage."""
+    active = {
+        "purchase_id": "purchase-active",
+        "telemetry": {"order_status_type": "IN_PROGRESS"},
+    }
+    api = AsyncMock(spec=WoltApi)
+    api.fetch_orders.return_value = [active]
+    api.fetch_order_details.side_effect = WoltInvalidPayloadError("changed")
+    coordinator = make_coordinator(hass, api)
+
+    await coordinator._async_update_data()
+    await coordinator._async_update_data()
+
+    assert (
+        caplog.messages.count("Rich Wolt order tracking details are unavailable") == 1
+    )
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        WoltConnectionError("offline"),
+        WoltRateLimitError("limited", status=429),
+        WoltInvalidPayloadError("invalid"),
+    ],
+)
+async def test_coordinator_translates_update_failures(
+    hass: HomeAssistant,
+    error: Exception,
+) -> None:
+    """Expose transient and contract failures as coordinator update failures."""
+    api = AsyncMock(spec=WoltApi)
+    api.fetch_orders.side_effect = error
+
+    with pytest.raises(UpdateFailed):
+        await make_coordinator(hass, api)._async_update_data()
+
+
+async def test_coordinator_translates_auth_failure_to_reauthentication(
+    hass: HomeAssistant,
+) -> None:
+    """Start Home Assistant's reauthentication path for rejected credentials."""
+    api = AsyncMock(spec=WoltApi)
+    api.fetch_orders.side_effect = WoltAuthenticationError("rejected", status=401)
+
+    with pytest.raises(ConfigEntryAuthFailed):
+        await make_coordinator(hass, api)._async_update_data()
+
+
+def test_poll_intervals_are_intentionally_conservative() -> None:
+    """Document the active and idle request-volume policy."""
+    assert timedelta(seconds=30) == ACTIVE_UPDATE_INTERVAL
+    assert timedelta(minutes=5) == IDLE_UPDATE_INTERVAL

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,82 @@
+"""Tests for privacy-preserving Wolt diagnostics."""
+
+import json
+from datetime import timedelta
+from unittest.mock import Mock
+
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.wait_for_wolt.const import (
+    CONF_BEARER_TOKEN,
+    CONF_REFRESH_TOKEN,
+    CONF_SESSION_ID,
+    CONF_VENUE_IDS,
+    DOMAIN,
+)
+from custom_components.wait_for_wolt.coordinator import (
+    WoltCoordinatorData,
+    WoltRuntimeData,
+)
+from custom_components.wait_for_wolt.diagnostics import (
+    async_get_config_entry_diagnostics,
+)
+
+
+async def test_diagnostics_expose_counts_without_credentials_or_order_pii(
+    hass: HomeAssistant,
+) -> None:
+    """Keep diagnostics useful without serializing private Wolt payloads."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_NAME: "Private account name",
+            CONF_SESSION_ID: "private-session-id",
+            CONF_BEARER_TOKEN: "private-access-token",
+            CONF_REFRESH_TOKEN: "private-refresh-token",
+        },
+        options={CONF_VENUE_IDS: ["private-venue-slug"]},
+    )
+    coordinator = Mock()
+    coordinator.data = WoltCoordinatorData(
+        orders={
+            "private-purchase-id": {
+                "purchase_id": "private-purchase-id",
+                "address": "Private address",
+            }
+        },
+        active_order_ids=frozenset({"private-purchase-id"}),
+        details={
+            "private-purchase-id": {
+                "driver_name": "Private courier",
+                "items": [{"name": "Private item"}],
+            }
+        },
+    )
+    coordinator.last_update_success = True
+    coordinator.update_interval = timedelta(seconds=30)
+    entry.runtime_data = WoltRuntimeData(Mock(), coordinator)
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+    serialized = json.dumps(diagnostics)
+
+    for private_value in (
+        "Private account name",
+        "private-session-id",
+        "private-access-token",
+        "private-refresh-token",
+        "private-venue-slug",
+        "private-purchase-id",
+        "Private address",
+        "Private courier",
+        "Private item",
+    ):
+        assert private_value not in serialized
+    assert diagnostics["coordinator"] == {
+        "last_update_success": True,
+        "known_order_count": 1,
+        "active_order_count": 1,
+        "rich_detail_count": 1,
+        "update_interval_seconds": 30,
+    }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,6 +6,11 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.wait_for_wolt.api import (
+    WoltApi,
+    WoltAuthenticationError,
+    WoltConnectionError,
+)
 from custom_components.wait_for_wolt.const import (
     CONF_BEARER_TOKEN,
     CONF_REFRESH_TOKEN,
@@ -13,46 +18,56 @@ from custom_components.wait_for_wolt.const import (
     CONF_VENUE_IDS,
     DOMAIN,
 )
+from custom_components.wait_for_wolt.coordinator import WoltCoordinatorData
 
 ENTRY_DATA = {
     "name": "Sanitized Wolt",
     CONF_SESSION_ID: "sanitized-session-id",
     CONF_BEARER_TOKEN: "sanitized-access-token",
     CONF_REFRESH_TOKEN: "sanitized-refresh-token",
-    CONF_VENUE_IDS: ["sanitized-venue"],
+    CONF_VENUE_IDS: [],
 }
 
 
-async def test_config_entry_setup_and_unload_cancel_polling(
+async def test_config_entry_setup_rotation_reload_and_unload(
     hass: HomeAssistant,
 ) -> None:
-    """Load the sensor platform and stop its polling callback on unload."""
+    """Own one coordinator, persist rotation, reload user edits, and unload."""
     entry = MockConfigEntry(domain=DOMAIN, data=ENTRY_DATA)
     entry.add_to_hass(hass)
-    cancel_interval = Mock()
+    api = Mock()
+    coordinator = Mock()
+    coordinator.data = WoltCoordinatorData({}, frozenset(), {})
+    coordinator.async_config_entry_first_refresh = AsyncMock()
+    cancel_listener = Mock()
+    coordinator.async_add_listener.return_value = cancel_listener
 
     with (
         patch(
-            "custom_components.wait_for_wolt.sensor.WoltApi.fetch_active_orders",
-            AsyncMock(return_value=[]),
-        ),
+            "custom_components.wait_for_wolt.WoltApi",
+            return_value=api,
+        ) as api_class,
         patch(
-            "custom_components.wait_for_wolt.sensor.WoltApi.fetch_venue_details",
-            AsyncMock(return_value=None),
-        ),
-        patch(
-            "custom_components.wait_for_wolt.sensor.async_track_time_interval",
-            return_value=cancel_interval,
-        ),
+            "custom_components.wait_for_wolt.WoltDataUpdateCoordinator",
+            return_value=coordinator,
+        ) as coordinator_class,
     ):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
         assert entry.state is ConfigEntryState.LOADED
+        coordinator.async_config_entry_first_refresh.assert_awaited_once_with()
+        coordinator_class.assert_called_once_with(hass, entry, api)
 
+        token_callback = api_class.call_args.kwargs["token_update_callback"]
         with patch.object(
             hass.config_entries, "async_reload", AsyncMock(return_value=True)
         ) as reload_entry:
-            # A user-supplied credential edit must reload the running client.
+            token_callback("rotated-access-token", "rotated-refresh-token")
+            await hass.async_block_till_done()
+            assert entry.data[CONF_BEARER_TOKEN] == "rotated-access-token"
+            assert entry.data[CONF_REFRESH_TOKEN] == "rotated-refresh-token"
+            reload_entry.assert_not_awaited()
+
             hass.config_entries.async_update_entry(
                 entry,
                 data={**entry.data, CONF_BEARER_TOKEN: "edited-access-token"},
@@ -60,24 +75,12 @@ async def test_config_entry_setup_and_unload_cancel_polling(
             await hass.async_block_till_done()
             reload_entry.assert_awaited_once_with(entry.entry_id)
 
-            # Simulate the completed reload, then a client-driven token rotation.
-            # The callback updates the runtime snapshot before entry persistence,
-            # so this internal update must not start a reload loop.
+            # Simulate the completed reload before checking an options-only edit.
             reload_entry.reset_mock()
             hass.data[DOMAIN][entry.entry_id] = {
                 "data": dict(entry.data),
                 "options": dict(entry.options),
             }
-            rotated_data = {
-                **entry.data,
-                CONF_BEARER_TOKEN: "rotated-access-token",
-                CONF_REFRESH_TOKEN: "rotated-refresh-token",
-            }
-            hass.data[DOMAIN][entry.entry_id]["data"] = dict(rotated_data)
-            hass.config_entries.async_update_entry(entry, data=rotated_data)
-            await hass.async_block_till_done()
-            reload_entry.assert_not_awaited()
-
             hass.config_entries.async_update_entry(
                 entry,
                 options={CONF_VENUE_IDS: ["second-sanitized-venue"]},
@@ -89,4 +92,43 @@ async def test_config_entry_setup_and_unload_cancel_polling(
         await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.NOT_LOADED
-    cancel_interval.assert_called_once_with()
+    cancel_listener.assert_called_once_with()
+
+
+async def test_transient_first_refresh_enters_setup_retry(
+    hass: HomeAssistant,
+) -> None:
+    """Use Home Assistant's retry lifecycle when Wolt is temporarily offline."""
+    entry = MockConfigEntry(domain=DOMAIN, data=ENTRY_DATA)
+    entry.add_to_hass(hass)
+
+    with patch.object(
+        WoltApi,
+        "fetch_orders",
+        AsyncMock(side_effect=WoltConnectionError("offline")),
+    ):
+        assert not await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_auth_first_refresh_starts_reauthentication(
+    hass: HomeAssistant,
+) -> None:
+    """Open the credential-replacement flow when Wolt rejects the entry."""
+    entry = MockConfigEntry(domain=DOMAIN, data=ENTRY_DATA)
+    entry.add_to_hass(hass)
+
+    with patch.object(
+        WoltApi,
+        "fetch_orders",
+        AsyncMock(side_effect=WoltAuthenticationError("rejected", status=401)),
+    ):
+        assert not await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+    assert len(flows) == 1
+    assert flows[0]["context"]["source"] == "reauth"
+    assert flows[0]["context"]["entry_id"] == entry.entry_id

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -9,6 +9,7 @@ import pytest
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.wait_for_wolt.api import WoltApi, WoltConnectionError
 from custom_components.wait_for_wolt.const import (
@@ -18,10 +19,15 @@ from custom_components.wait_for_wolt.const import (
     CONF_VENUE_IDS,
     DOMAIN,
 )
+from custom_components.wait_for_wolt.coordinator import (
+    WoltCoordinatorData,
+    WoltDataUpdateCoordinator,
+    WoltRuntimeData,
+)
 from custom_components.wait_for_wolt.sensor import (
     WoltOrderSensor,
     WoltVenueSensor,
-    _setup_sensors,
+    async_setup_entry,
     async_setup_platform,
 )
 
@@ -29,6 +35,15 @@ from custom_components.wait_for_wolt.sensor import (
 def load_json_fixture(name: str) -> Any:
     """Load a sanitized fixture."""
     return json.loads((Path(__file__).parent / "fixtures" / name).read_text())
+
+
+def mock_coordinator(data: WoltCoordinatorData) -> Mock:
+    """Create the coordinator surface consumed by entities and setup."""
+    coordinator = Mock(spec=WoltDataUpdateCoordinator)
+    coordinator.data = data
+    coordinator.last_update_success = True
+    coordinator.async_add_listener.return_value = Mock()
+    return coordinator
 
 
 async def test_legacy_yaml_platform_starts_config_entry_import(
@@ -57,142 +72,75 @@ async def test_legacy_yaml_platform_starts_config_entry_import(
     )
 
 
-async def test_initial_active_order_is_added_once() -> None:
-    """Avoid submitting the same initial order entity twice to Home Assistant."""
-    add_entities = Mock()
-    cancel_interval = Mock()
-
-    with (
-        patch("custom_components.wait_for_wolt.sensor.async_get_clientsession"),
-        patch(
-            "custom_components.wait_for_wolt.sensor.WoltApi.fetch_active_orders",
-            AsyncMock(return_value=[{"purchase_id": "sanitized-purchase-001"}]),
-        ),
-        patch(
-            "custom_components.wait_for_wolt.sensor.async_track_time_interval",
-            return_value=cancel_interval,
-        ),
-    ):
-        returned_cancel = await _setup_sensors(
-            Mock(),
-            add_entities,
-            "Sanitized Wolt",
-            "sanitized-session-id",
-            "sanitized-access-token",
-            "sanitized-refresh-token",
+async def test_initial_active_order_is_added_once(hass: HomeAssistant) -> None:
+    """Add the first coordinator order once and register dynamic discovery."""
+    order_id = "sanitized-purchase-001"
+    coordinator = mock_coordinator(
+        WoltCoordinatorData(
+            orders={order_id: {"purchase_id": order_id}},
+            active_order_ids=frozenset({order_id}),
+            details={order_id: {"status": "delivery"}},
         )
-
-    assert returned_cancel is cancel_interval
-    assert add_entities.call_count == 1
-    entities = add_entities.call_args.args[0]
-    assert [entity.order_id for entity in entities] == ["sanitized-purchase-001"]
-    assert add_entities.call_args.kwargs == {"update_before_add": True}
-
-
-async def test_polling_discovers_only_new_orders_after_empty_response() -> None:
-    """Discover a later order once and tolerate subsequent empty responses."""
+    )
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_NAME: "Sanitized Wolt", CONF_VENUE_IDS: []},
+    )
+    entry.runtime_data = WoltRuntimeData(Mock(spec=WoltApi), coordinator)
+    entry.add_to_hass(hass)
     add_entities = Mock()
-    scheduled_update = None
 
-    def capture_interval(_hass: Any, update: Any, _interval: Any) -> Mock:
-        nonlocal scheduled_update
-        scheduled_update = update
-        return Mock()
-
-    with (
-        patch("custom_components.wait_for_wolt.sensor.async_get_clientsession"),
-        patch(
-            "custom_components.wait_for_wolt.sensor.WoltApi.fetch_active_orders",
-            AsyncMock(
-                side_effect=[
-                    [],
-                    [{"purchase_id": "sanitized-purchase-001"}],
-                    [],
-                    [{"purchase_id": "sanitized-purchase-001"}],
-                ]
-            ),
-        ),
-        patch(
-            "custom_components.wait_for_wolt.sensor.async_track_time_interval",
-            side_effect=capture_interval,
-        ),
-    ):
-        await _setup_sensors(
-            Mock(),
-            add_entities,
-            "Sanitized Wolt",
-            "sanitized-session-id",
-            "sanitized-access-token",
-            "sanitized-refresh-token",
-        )
-        assert scheduled_update is not None
-        await scheduled_update()
-        await scheduled_update()
-        await scheduled_update()
+    await async_setup_entry(hass, entry, add_entities)
+    listener = coordinator.async_add_listener.call_args.args[0]
+    listener()
 
     assert add_entities.call_count == 1
     entities = add_entities.call_args.args[0]
-    assert [entity.order_id for entity in entities] == ["sanitized-purchase-001"]
+    assert [entity.order_id for entity in entities] == [order_id]
+    assert add_entities.call_args.kwargs == {}
 
 
-async def test_config_entry_persists_rotated_tokens_via_api_callback() -> None:
-    """Keep Home Assistant persistence outside the extracted API layer."""
-    hass = Mock()
-    entry = Mock(
-        data={
-            "session_id": "test-session",
-            "bearer_token": "old-access-token",
-            "refresh_token": "old-refresh-token",
-            "preserved": True,
-        }
+async def test_coordinator_listener_discovers_only_new_orders(
+    hass: HomeAssistant,
+) -> None:
+    """Add an order discovered by a later shared refresh exactly once."""
+    coordinator = mock_coordinator(WoltCoordinatorData({}, frozenset(), {}))
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_NAME: "Sanitized Wolt"})
+    entry.runtime_data = WoltRuntimeData(Mock(spec=WoltApi), coordinator)
+    entry.add_to_hass(hass)
+    add_entities = Mock()
+
+    await async_setup_entry(hass, entry, add_entities)
+    listener = coordinator.async_add_listener.call_args.args[0]
+    order_id = "sanitized-purchase-001"
+    coordinator.data = WoltCoordinatorData(
+        orders={order_id: {"purchase_id": order_id}},
+        active_order_ids=frozenset({order_id}),
+        details={order_id: {"status": "delivery"}},
     )
-    api = Mock(spec=WoltApi)
-    api.fetch_active_orders = AsyncMock(return_value=[])
+    listener()
+    listener()
 
-    with (
-        patch("custom_components.wait_for_wolt.sensor.async_get_clientsession"),
-        patch(
-            "custom_components.wait_for_wolt.sensor.WoltApi", return_value=api
-        ) as api_cls,
-        patch("custom_components.wait_for_wolt.sensor.async_track_time_interval"),
-    ):
-        await _setup_sensors(
-            hass,
-            Mock(),
-            "Wolt",
-            "test-session",
-            "old-access-token",
-            "old-refresh-token",
-            entry=entry,
-        )
-
-    callback = api_cls.call_args.kwargs["token_update_callback"]
-    callback("new-access-token", "new-refresh-token")
-
-    hass.config_entries.async_update_entry.assert_called_once_with(
-        entry,
-        data={
-            "session_id": "test-session",
-            "bearer_token": "new-access-token",
-            "refresh_token": "new-refresh-token",
-            "preserved": True,
-        },
-    )
+    assert add_entities.call_count == 1
+    assert [entity.order_id for entity in add_entities.call_args.args[0]] == [order_id]
 
 
 async def test_order_sensor_state_attributes_and_availability() -> None:
-    """Expose a sanitized order response and become unavailable on API failure."""
-    api = AsyncMock(spec=WoltApi)
-    api.fetch_order_details.return_value = load_json_fixture("order_details.json")[
-        "order_details"
-    ][0]
+    """Expose one sanitized order from the coordinator's coherent snapshot."""
+    order_id = "sanitized-order-001"
+    details = load_json_fixture("order_details.json")["order_details"][0]
+    coordinator = mock_coordinator(
+        WoltCoordinatorData(
+            orders={order_id: {"purchase_id": order_id}},
+            active_order_ids=frozenset({order_id}),
+            details={order_id: details},
+        )
+    )
     sensor = WoltOrderSensor(
-        api,
-        "sanitized-order-001",
+        coordinator,
+        order_id,
         "Wolt sanitized-order-001",
     )
-
-    await sensor.async_update()
 
     assert sensor.unique_id == "wolt_sanitized-order-001"
     assert sensor.native_value == "delivery"
@@ -205,25 +153,46 @@ async def test_order_sensor_state_attributes_and_availability() -> None:
         "items": ["Sanitized item"],
     }
 
-    api.fetch_order_details.side_effect = WoltConnectionError("offline")
-    await sensor.async_update()
-
+    coordinator.last_update_success = False
     assert not sensor.available
 
 
 async def test_order_sensor_normalizes_current_status_object() -> None:
     """Expose the current purchase-tracking status object as a scalar state."""
-    api = AsyncMock(spec=WoltApi)
-    api.fetch_order_details.return_value = {
-        "status": {"value": "In progress"},
-        "venue_name": "Sanitized Test Venue",
-    }
-    sensor = WoltOrderSensor(api, "sanitized-order-001", "Wolt order")
-
-    await sensor.async_update()
+    order_id = "sanitized-order-001"
+    coordinator = mock_coordinator(
+        WoltCoordinatorData(
+            orders={order_id: {"purchase_id": order_id}},
+            active_order_ids=frozenset({order_id}),
+            details={order_id: {"status": {"value": "In progress"}}},
+        )
+    )
+    sensor = WoltOrderSensor(coordinator, order_id, "Wolt order")
 
     assert sensor.available
     assert sensor.native_value == "In progress"
+
+
+async def test_order_sensor_keeps_final_status_from_order_summary() -> None:
+    """Expose a delivered transition after rich active tracking stops."""
+    order_id = "sanitized-order-001"
+    coordinator = mock_coordinator(
+        WoltCoordinatorData(
+            orders={
+                order_id: {
+                    "purchase_id": order_id,
+                    "status": {"value": "Delivered"},
+                    "telemetry": {"order_status_type": "DELIVERED"},
+                }
+            },
+            active_order_ids=frozenset(),
+            details={},
+        )
+    )
+    sensor = WoltOrderSensor(coordinator, order_id, "Wolt order")
+
+    assert sensor.available
+    assert sensor.native_value == "Delivered"
 
 
 @pytest.mark.parametrize(
@@ -249,3 +218,20 @@ async def test_venue_sensor_state_and_availability(
     await sensor.async_update()
 
     assert not sensor.available
+
+
+async def test_venue_sensor_respects_explicit_closed_status() -> None:
+    """Prefer an explicit closed status over broader online metadata."""
+    api = AsyncMock(spec=WoltApi)
+    api.fetch_venue_details.return_value = {
+        "venue": {
+            "online": True,
+            "delivery_open_status": {"is_open": False},
+        }
+    }
+    sensor = WoltVenueSensor(api, "sanitized-venue", "Wolt sanitized-venue")
+
+    await sensor.async_update()
+
+    assert sensor.available
+    assert sensor.native_value == "closed"


### PR DESCRIPTION
## Summary

Complete the canonical-core architecture tracked by #20:

- create one config-entry `DataUpdateCoordinator` for account orders
- fetch the orders page exactly once per cycle and rich tracking once per active order
- adapt authenticated polling from five minutes while idle to 30 seconds while active
- keep rich tracking optional: order summaries remain usable when that endpoint is unavailable
- fan one coherent snapshot out to dynamically discovered `CoordinatorEntity` order sensors
- preserve final status transitions from the orders-page summary
- translate authentication failures to Home Assistant reauthentication, transient first-refresh failures to setup retry, and runtime failures to coordinator availability
- add password-masked setup/options/reauth fields without prefilling saved tokens
- add privacy-preserving diagnostics containing counts only—never credentials, account names, venue slugs, purchase IDs, addresses, couriers, items, or raw payloads
- poll public venue sensors every five minutes and preserve explicit closed status
- retain current config-entry and unique-ID compatibility; legacy YAML remains one-time import only

This closes #20 and advances #22.

## Verification

Exact head: `78ece53371aa0c9213b7f83b708146339a5958d9`

- `git diff --check`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest` → **50 passed**
- Hassfest container → **1 integration, 0 invalid**
- `detect-secrets` with caches/lock excluded → **0 findings**
- synthetic tests cover multiple active orders, no orders, active/idle intervals, optional rich-endpoint degradation, one-time warning behavior, setup retry, reauthentication, unload cleanup, dynamic entity discovery, final status transitions, credential masking/preservation, and diagnostics redaction

No real Wolt or Home Assistant credentials, order payloads, or network calls were used.

Closes #20
Refs #22
