### PR TITLE
fix: address immutable review blockers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,10 +46,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   of making every order entity unavailable.
 - Venue sensors now preserve an explicit closed status even when broader venue
   metadata still reports the venue online.
+- Authoritative telemetry states other than `IN_PROGRESS` can no longer fall
+  through to legacy heuristics and create false active-order entities.
+- Loaded-entry reauthentication now schedules exactly one reload instead of
+  duplicating the immediate post-credential-update polling cycle.
 
 ### Security
 
 - Rotated credentials are persisted without being logged.
 - Documentation and tests explicitly prohibit real Wolt or Home Assistant secrets.
+- Venue-update warnings no longer include configured venue slugs.
 
 [Unreleased]: https://github.com/selfish/ha-wait-for-wolt/compare/main...HEAD

--- a/custom_components/wait_for_wolt/api.py
+++ b/custom_components/wait_for_wolt/api.py
@@ -22,15 +22,6 @@ REQUEST_TIMEOUT = 10
 
 TokenUpdateCallback = Callable[[str, str], Awaitable[None] | None]
 
-FINAL_ORDER_STATUS_TYPES = {
-    "DELIVERED",
-    "CANCELED",
-    "CANCELLED",
-    "REFUNDED",
-    "REJECTED",
-    "FAILED",
-}
-
 
 def is_active_order(order: dict[str, Any]) -> bool:
     """Return whether an order-list item represents a trackable active order."""
@@ -40,12 +31,11 @@ def is_active_order(order: dict[str, Any]) -> bool:
         if isinstance(telemetry, dict)
         else order.get("order_status_type")
     )
-    if status_type:
-        normalized = str(status_type).upper()
-        if normalized == "IN_PROGRESS":
-            return True
-        if normalized in FINAL_ORDER_STATUS_TYPES:
-            return False
+    if status_type is not None:
+        # Current Wolt order-list payloads provide an authoritative telemetry
+        # state. Do not let legacy CTA/text heuristics override any non-active
+        # telemetry value such as COMPLETED or PENDING.
+        return str(status_type).upper() == "IN_PROGRESS"
 
     call_to_action = order.get("call_to_action")
     if isinstance(call_to_action, dict):

--- a/custom_components/wait_for_wolt/config_flow.py
+++ b/custom_components/wait_for_wolt/config_flow.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import voluptuous as vol
 from homeassistant import config_entries
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_NAME
 from homeassistant.helpers.selector import (
     TextSelector,
@@ -77,14 +78,24 @@ class WoltConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Replace rejected credentials and reload the config entry."""
         entry = self._get_reauth_entry()
         if user_input is not None:
+            data_updates = {
+                CONF_SESSION_ID: user_input.get(CONF_SESSION_ID)
+                or entry.data.get(CONF_SESSION_ID, ""),
+                CONF_BEARER_TOKEN: user_input[CONF_BEARER_TOKEN],
+                CONF_REFRESH_TOKEN: user_input[CONF_REFRESH_TOKEN],
+            }
+            if entry.state is ConfigEntryState.LOADED:
+                # The loaded entry's update listener owns the one required
+                # reload. Scheduling another here causes duplicate Wolt polls.
+                return self.async_update_and_abort(
+                    entry,
+                    data_updates=data_updates,
+                )
+            # First-refresh reauth has no update listener yet, so the flow must
+            # explicitly schedule setup with the replacement credentials.
             return self.async_update_reload_and_abort(
                 entry,
-                data_updates={
-                    CONF_SESSION_ID: user_input.get(CONF_SESSION_ID)
-                    or entry.data.get(CONF_SESSION_ID, ""),
-                    CONF_BEARER_TOKEN: user_input[CONF_BEARER_TOKEN],
-                    CONF_REFRESH_TOKEN: user_input[CONF_REFRESH_TOKEN],
-                },
+                data_updates=data_updates,
             )
 
         schema = vol.Schema(

--- a/custom_components/wait_for_wolt/const.py
+++ b/custom_components/wait_for_wolt/const.py
@@ -9,8 +9,6 @@ CONF_VENUE_IDS = "venue_ids"
 
 DEFAULT_NAME = "Wolt Order"
 
-UPDATE_INTERVAL = 60  # seconds
-
 REFRESH_URL = "https://authentication.wolt.com/v1/wauth2/access_token"
 # Updated endpoints based on the current Wolt web client
 ACTIVE_ORDERS_URL = "https://consumer-api.wolt.com/order-xp/web/v1/pages/orders"

--- a/custom_components/wait_for_wolt/sensor.py
+++ b/custom_components/wait_for_wolt/sensor.py
@@ -191,11 +191,11 @@ class WoltVenueSensor(SensorEntity):
             details = await self.api.fetch_venue_details(self.slug)
         except WoltApiError as err:
             self._attr_available = False
-            _LOGGER.warning("Unable to update Wolt venue %s: %s", self.slug, err)
+            _LOGGER.warning("Unable to update a configured Wolt venue: %s", err)
             return
         if not details:
             self._attr_available = False
-            _LOGGER.warning("Venue %s details not found", self.slug)
+            _LOGGER.warning("Configured Wolt venue details were not found")
             return
 
         venue = details.get("venue") or details.get("venue_info") or {}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -114,19 +114,38 @@ async def test_active_orders_success_uses_current_token_first() -> None:
     assert session.calls[0]["headers"]["w-wolt-session-id"] == "test-session"
 
 
-async def test_active_orders_excludes_completed_history() -> None:
-    """Do not create entities for completed orders returned by the orders page."""
+@pytest.mark.parametrize(
+    "status_type",
+    ["DELIVERED", "COMPLETED", "PENDING", "UNKNOWN", ""],
+)
+async def test_active_orders_rejects_every_non_active_telemetry_state(
+    status_type: str,
+) -> None:
+    """Treat telemetry as authoritative even when legacy hints look active."""
     active = {
         "purchase_id": "purchase-active",
         "telemetry": {"order_status_type": "IN_PROGRESS"},
     }
-    completed = {
-        "purchase_id": "purchase-complete",
-        "telemetry": {"order_status_type": "DELIVERED"},
+    not_active = {
+        "purchase_id": "purchase-not-active",
+        "telemetry": {"order_status_type": status_type},
+        "call_to_action": {"type": "ORDER_TRACKING"},
+        "status": {"value": "Preparing"},
     }
-    session = FakeSession(FakeResponse(200, {"orders": [active, completed]}))
+    session = FakeSession(FakeResponse(200, {"orders": [active, not_active]}))
 
     assert await make_api(session).fetch_active_orders() == [active]
+
+
+async def test_active_orders_keeps_legacy_tracking_fallback_without_telemetry() -> None:
+    """Keep compatibility with older order items that omit telemetry entirely."""
+    legacy_active = {
+        "order_id": "legacy-order-active",
+        "call_to_action": {"type": "ORDER_TRACKING"},
+    }
+    session = FakeSession(FakeResponse(200, {"orders": [legacy_active]}))
+
+    assert await make_api(session).fetch_active_orders() == [legacy_active]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,8 +2,9 @@
 
 from unittest.mock import AsyncMock, Mock, patch
 
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.wait_for_wolt.api import (
@@ -132,3 +133,52 @@ async def test_auth_first_refresh_starts_reauthentication(
     assert len(flows) == 1
     assert flows[0]["context"]["source"] == "reauth"
     assert flows[0]["context"]["entry_id"] == entry.entry_id
+
+
+async def test_loaded_entry_reauthentication_schedules_exactly_one_reload(
+    hass: HomeAssistant,
+) -> None:
+    """Let the loaded entry update listener exclusively own reauth reload."""
+    entry = MockConfigEntry(domain=DOMAIN, data=ENTRY_DATA)
+    entry.add_to_hass(hass)
+    api = Mock()
+    coordinator = Mock()
+    coordinator.data = WoltCoordinatorData({}, frozenset(), {})
+    coordinator.async_config_entry_first_refresh = AsyncMock()
+
+    with (
+        patch("custom_components.wait_for_wolt.WoltApi", return_value=api),
+        patch(
+            "custom_components.wait_for_wolt.WoltDataUpdateCoordinator",
+            return_value=coordinator,
+        ),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        assert entry.state is ConfigEntryState.LOADED
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_REAUTH, "entry_id": entry.entry_id},
+            data=entry.data,
+        )
+        assert result["type"] is FlowResultType.FORM
+
+        with patch.object(
+            hass.config_entries,
+            "async_reload",
+            AsyncMock(return_value=True),
+        ) as reload_entry:
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                {
+                    CONF_SESSION_ID: "",
+                    CONF_BEARER_TOKEN: "sanitized-access-token-next",
+                    CONF_REFRESH_TOKEN: "sanitized-refresh-token-next",
+                },
+            )
+            await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    reload_entry.assert_awaited_once_with(entry.entry_id)


### PR DESCRIPTION
## Summary

Address both blocking findings returned by the delayed immutable reviews of PRs #26 and #27:

- treat a present Wolt telemetry state as authoritative and accept only `IN_PROGRESS` as active
- prevent legacy CTA/status heuristics from reactivating `COMPLETED`, `PENDING`, unknown, or empty telemetry states
- let the loaded config entry's update listener exclusively own reauthentication reloads
- retain explicit reload scheduling for first-refresh/unloaded reauthentication, where no listener exists yet
- remove configured venue slugs from warning logs
- remove the obsolete pre-coordinator polling constant

## Regression coverage

- all representative non-`IN_PROGRESS` telemetry states, including misleading active-looking CTA/text
- legacy no-telemetry fallback
- loaded-entry reauthentication with exactly one reload
- first-refresh/unloaded reauthentication remains covered by the existing explicit-reload test

## Local verification

At exact head `64e67b3d804b05ab5be3c6097c4abcbcf0c0578e`:

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest` — 56 passed
- `git diff --check`
- Hassfest — 1 integration, 0 invalid
- `detect-secrets 1.5.0` — 0 findings

## Review provenance

This PR is a focused corrective follow-up to blocking findings from immutable-SHA reviews that completed after #26 and #27 had already merged. The object-valued status finding from the old #26 head was already fixed before its final merged head; this PR resolves the remaining telemetry classification finding and the #27 duplicate-reload finding.
