### PR TITLE
fix: keep present telemetry authoritative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   metadata still reports the venue online.
 - Authoritative telemetry states other than `IN_PROGRESS` can no longer fall
   through to legacy heuristics and create false active-order entities.
+- Present but incomplete or malformed telemetry is also treated as authoritative
+  and cannot fall through to active-looking legacy hints.
 - Loaded-entry reauthentication now schedules exactly one reload instead of
   duplicating the immediate post-credential-update polling cycle.
 - Existing order status entities migrate to the scoped identity without losing

--- a/custom_components/wait_for_wolt/api.py
+++ b/custom_components/wait_for_wolt/api.py
@@ -25,17 +25,19 @@ TokenUpdateCallback = Callable[[str, str], Awaitable[None] | None]
 
 def is_active_order(order: dict[str, Any]) -> bool:
     """Return whether an order-list item represents a trackable active order."""
-    telemetry = order.get("telemetry")
-    status_type = (
-        telemetry.get("order_status_type")
-        if isinstance(telemetry, dict)
-        else order.get("order_status_type")
-    )
-    if status_type is not None:
+    if "telemetry" in order:
+        telemetry = order["telemetry"]
+        status_type = (
+            telemetry.get("order_status_type") if isinstance(telemetry, dict) else None
+        )
         # Current Wolt order-list payloads provide an authoritative telemetry
-        # state. Do not let legacy CTA/text heuristics override any non-active
-        # telemetry value such as COMPLETED or PENDING.
+        # object. Its absence from an otherwise present/malformed object must
+        # not reactivate an order through legacy CTA/text heuristics.
         return str(status_type).upper() == "IN_PROGRESS"
+    if "order_status_type" in order:
+        # Older payloads occasionally exposed the same authoritative state at
+        # the top level instead of inside ``telemetry``.
+        return str(order["order_status_type"]).upper() == "IN_PROGRESS"
 
     call_to_action = order.get("call_to_action")
     if isinstance(call_to_action, dict):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -149,6 +149,41 @@ async def test_active_orders_keeps_legacy_tracking_fallback_without_telemetry() 
 
 
 @pytest.mark.parametrize(
+    "telemetry",
+    [{}, None, [], {"order_status_type": None}],
+)
+async def test_active_orders_rejects_present_incomplete_telemetry(
+    telemetry: Any,
+) -> None:
+    """Never let a malformed present telemetry object reach legacy heuristics."""
+    not_active = {
+        "purchase_id": "purchase-not-active",
+        "telemetry": telemetry,
+        "call_to_action": {"type": "ORDER_TRACKING"},
+        "status": {"value": "Preparing"},
+    }
+    session = FakeSession(FakeResponse(200, {"orders": [not_active]}))
+
+    assert await make_api(session).fetch_active_orders() == []
+
+
+@pytest.mark.parametrize("status_type", ["IN_PROGRESS", "COMPLETED", None])
+async def test_active_orders_treats_legacy_top_level_status_as_authoritative(
+    status_type: str | None,
+) -> None:
+    """Apply the same strict contract to the older top-level status field."""
+    order = {
+        "order_id": "legacy-order",
+        "order_status_type": status_type,
+        "call_to_action": {"type": "ORDER_TRACKING"},
+    }
+    session = FakeSession(FakeResponse(200, {"orders": [order]}))
+
+    expected = [order] if status_type == "IN_PROGRESS" else []
+    assert await make_api(session).fetch_active_orders() == expected
+
+
+@pytest.mark.parametrize(
     ("method_name", "payload", "args"),
     [
         ("fetch_active_orders", {"orders": {"unexpected": "shape"}}, ()),


### PR DESCRIPTION
## Summary

Close the remaining blocker from the delayed immutable review of PR #28:

- distinguish an absent telemetry key from telemetry that is present but null, empty, incomplete, or malformed
- allow legacy CTA/status heuristics only when both telemetry and the older top-level status field are absent
- treat older top-level `order_status_type` as authoritative when present

## Regression coverage

- `telemetry: {}`
- `telemetry: null`
- malformed telemetry lists
- `telemetry.order_status_type: null`
- misleading tracking CTA and active-looking status text
- legacy top-level `IN_PROGRESS`, `COMPLETED`, and null values
- legacy fallback when telemetry is genuinely absent

## Verification

At exact head `3a5c1aa76da7ac72586556ffb0b1b8dfcc251c7c`:

- Ruff lint and format passed
- pytest: 79 passed
- `git diff --check` passed
- Hassfest: 1 integration, 0 invalid
- `detect-secrets`: 0 findings

Follow-up to #28.
