### PR TITLE
fix: address entity review blockers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   through to legacy heuristics and create false active-order entities.
 - Present but incomplete or malformed telemetry is also treated as authoritative
   and cannot fall through to active-looking legacy hints.
+- Telemetry now remains authoritative over conflicting stale display text in status
+  entities, while `IN_PROGRESS` still permits non-final rich display details.
+- Duration-like or implausible numeric ETA values are rejected instead of becoming
+  bogus Unix-epoch timestamps.
+- Existing legacy or scoped order entities are restored after restart even when the
+  retained order has already reached a final state.
+- User-facing order device names and entity attributes no longer expose order IDs or
+  venue labels.
 - Loaded-entry reauthentication now schedules exactly one reload instead of
   duplicating the immediate post-credential-update polling cycle.
 - Existing order status entities migrate to the scoped identity without losing

--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ a reauthentication flow for replacement tokens.
   cycle, and optional rich tracking failures fall back to the order summary.
 - Each in-progress purchase gets a device with a stable enum status sensor and a
   timestamp ETA sensor. Existing status entities are migrated to config-entry-scoped
-  unique IDs. Order item lists, payment values, addresses, and raw API payloads are
-  intentionally not exposed as entity attributes.
+  unique IDs. Order identifiers, venue labels, item lists, payment values, addresses,
+  and raw API payloads are intentionally not exposed in user-facing device names or
+  entity attributes.
 - New orders placed while Home Assistant is running are discovered automatically within the polling interval.
 - If you configure `venue_ids`, sensors poll the public venue endpoint every five
   minutes, report whether it is open, and expose delivery price and estimates when

--- a/custom_components/wait_for_wolt/sensor.py
+++ b/custom_components/wait_for_wolt/sensor.py
@@ -39,7 +39,7 @@ _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(minutes=5)
 
-ORDER_STATUS_OPTIONS = (
+ORDER_STATUS_OPTIONS = [
     "pending",
     "preparing",
     "ready_for_pickup",
@@ -50,7 +50,7 @@ ORDER_STATUS_OPTIONS = (
     "cancelled",
     "failed",
     "unknown",
-)
+]
 
 ORDER_STATUS_DESCRIPTION = SensorEntityDescription(
     key="status",
@@ -67,17 +67,42 @@ ORDER_ETA_DESCRIPTION = SensorEntityDescription(
 
 
 def _raw_status(order: dict[str, Any]) -> str | None:
-    """Extract a scalar status from current and legacy Wolt payloads."""
+    """Extract a scalar status while respecting authoritative telemetry."""
+    status_type: Any = None
+    if "telemetry" in order:
+        telemetry = order["telemetry"]
+        status_type = (
+            telemetry.get("order_status_type") if isinstance(telemetry, dict) else None
+        )
+        if str(status_type).upper() != "IN_PROGRESS":
+            return str(status_type) if status_type is not None else None
+    elif "order_status_type" in order:
+        status_type = order["order_status_type"]
+        if str(status_type).upper() != "IN_PROGRESS":
+            return str(status_type) if status_type is not None else None
+
     status = order.get("status")
     if isinstance(status, dict):
         status = status.get("value") or status.get("text") or status.get("label")
     if status is None:
-        telemetry = order.get("telemetry")
-        status = (
-            telemetry.get("order_status_type")
-            if isinstance(telemetry, dict)
-            else order.get("order_status_type")
+        status = status_type
+    if str(status_type).upper() == "IN_PROGRESS" and status is not None:
+        display_status = re.sub(r"[^a-z0-9]+", "_", str(status).strip().lower()).strip(
+            "_"
         )
+        if any(
+            token in display_status
+            for token in (
+                "delivered",
+                "completed",
+                "finished",
+                "cancel",
+                "fail",
+                "reject",
+                "refund",
+            )
+        ):
+            return str(status_type)
     return str(status) if status is not None else None
 
 
@@ -125,6 +150,10 @@ def _parse_eta(value: Any) -> datetime | None:
         return None
     if isinstance(value, int | float):
         timestamp = value / 1000 if value > 10_000_000_000 else value
+        # Explicit ETAs must be plausible wall-clock timestamps. Small values
+        # are durations/range bounds, not Unix timestamps.
+        if not 1_577_836_800 <= timestamp <= 4_102_444_800:
+            return None
         try:
             return datetime.fromtimestamp(timestamp, UTC)
         except OSError, OverflowError, ValueError:
@@ -201,30 +230,43 @@ async def async_setup_entry(
 
     @callback
     def async_add_new_orders() -> None:
-        new_order_ids = coordinator.data.active_order_ids - known_order_ids
+        registry = er.async_get(hass)
+        candidate_order_ids = set(coordinator.data.active_order_ids)
+        for order_id in coordinator.data.orders:
+            if any(
+                _owned_registry_entity(
+                    registry,
+                    entry.entry_id,
+                    unique_id,
+                )
+                is not None
+                for unique_id in (
+                    f"wolt_{order_id}",
+                    _order_unique_id(entry.entry_id, order_id, "status"),
+                    _order_unique_id(entry.entry_id, order_id, "eta"),
+                )
+            ):
+                candidate_order_ids.add(order_id)
+
+        new_order_ids = candidate_order_ids - known_order_ids
         if not new_order_ids:
             return
         known_order_ids.update(new_order_ids)
         entities: list[SensorEntity] = []
-        registry = er.async_get(hass)
         for order_id in sorted(new_order_ids):
             status_unique_id = _order_unique_id(entry.entry_id, order_id, "status")
-            legacy_entity_id = registry.async_get_entity_id(
-                "sensor", DOMAIN, f"wolt_{order_id}"
-            )
-            legacy_entity = (
-                registry.async_get(legacy_entity_id)
-                if legacy_entity_id is not None
-                else None
+            legacy_entity = _owned_registry_entity(
+                registry,
+                entry.entry_id,
+                f"wolt_{order_id}",
             )
             if (
                 legacy_entity is not None
-                and legacy_entity.config_entry_id == entry.entry_id
                 and registry.async_get_entity_id("sensor", DOMAIN, status_unique_id)
                 is None
             ):
                 registry.async_update_entity(
-                    legacy_entity_id,
+                    legacy_entity.entity_id,
                     new_unique_id=status_unique_id,
                     translation_key="order_status",
                     has_entity_name=True,
@@ -239,6 +281,17 @@ async def async_setup_entry(
 
     async_add_new_orders()
     entry.async_on_unload(coordinator.async_add_listener(async_add_new_orders))
+
+
+def _owned_registry_entity(
+    registry: er.EntityRegistry,
+    entry_id: str,
+    unique_id: str,
+) -> er.RegistryEntry | None:
+    """Return a sensor registry entity only when this config entry owns it."""
+    entity_id = registry.async_get_entity_id("sensor", DOMAIN, unique_id)
+    entity = registry.async_get(entity_id) if entity_id is not None else None
+    return entity if entity is not None and entity.config_entry_id == entry_id else None
 
 
 def _order_unique_id(entry_id: str, order_id: str, key: str) -> str:
@@ -278,12 +331,11 @@ class WoltOrderEntity(CoordinatorEntity[WoltDataUpdateCoordinator], SensorEntity
     @property
     def device_info(self) -> DeviceInfo:
         """Group status and ETA under a stable per-purchase device."""
-        suffix = self.order_id[-6:] if len(self.order_id) > 6 else self.order_id
         return DeviceInfo(
             identifiers={(DOMAIN, f"{self._entry_id}:{self.order_id}")},
             manufacturer="Wolt",
             model="Delivery order",
-            name=f"Wolt order •••{suffix}",
+            name="Wolt order",
         )
 
 
@@ -309,9 +361,8 @@ class WoltOrderStatusSensor(WoltOrderEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        """Expose only a documented venue label, never order payload fragments."""
-        venue_name = self._order_data.get("venue_name")
-        return {"venue_name": venue_name} if isinstance(venue_name, str) else {}
+        """Never persist order metadata or payload fragments as attributes."""
+        return {}
 
 
 class WoltOrderEtaSensor(WoltOrderEntity):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -160,10 +160,11 @@ async def test_order_entities_are_typed_scoped_and_privacy_safe() -> None:
     assert eta.native_value == datetime(2030, 1, 1, 12, 30, tzinfo=UTC)
     assert status.available
     assert eta.available
-    assert status.extra_state_attributes == {"venue_name": "Sanitized Test Venue"}
+    assert status.extra_state_attributes == {}
     assert "Sanitized item" not in json.dumps(status.extra_state_attributes)
     assert "0.00 TEST" not in json.dumps(status.extra_state_attributes)
     assert status.device_info == eta.device_info
+    assert order_id not in status.device_info["name"]
 
     coordinator.last_update_success = False
     assert not status.available
@@ -208,6 +209,49 @@ async def test_order_sensor_keeps_final_status_from_order_summary() -> None:
     assert sensor.native_value == "delivered"
 
 
+async def test_final_telemetry_overrides_stale_display_status() -> None:
+    """Never let stale display text hide an authoritative final state."""
+    order_id = "sanitized-order-001"
+    coordinator = mock_coordinator(
+        WoltCoordinatorData(
+            orders={
+                order_id: {
+                    "purchase_id": order_id,
+                    "status": {"value": "In progress"},
+                    "telemetry": {"order_status_type": "DELIVERED"},
+                }
+            },
+            active_order_ids=frozenset(),
+            details={},
+        )
+    )
+
+    sensor = WoltOrderStatusSensor(coordinator, "entry-001", order_id)
+
+    assert sensor.native_value == "delivered"
+
+
+async def test_in_progress_telemetry_rejects_stale_final_display_status() -> None:
+    """Keep an authoritative active order active despite stale final display text."""
+    order_id = "sanitized-order-001"
+    coordinator = mock_coordinator(
+        WoltCoordinatorData(
+            orders={order_id: {"purchase_id": order_id}},
+            active_order_ids=frozenset({order_id}),
+            details={
+                order_id: {
+                    "status": {"value": "Delivered"},
+                    "telemetry": {"order_status_type": "IN_PROGRESS"},
+                }
+            },
+        )
+    )
+
+    sensor = WoltOrderStatusSensor(coordinator, "entry-001", order_id)
+
+    assert sensor.native_value == "pending"
+
+
 @pytest.mark.parametrize(
     ("raw", "expected"),
     [
@@ -231,6 +275,10 @@ def test_order_status_normalization_is_stable(raw: str, expected: str) -> None:
     [
         ("2030-01-01T12:30:00Z", datetime(2030, 1, 1, 12, 30, tzinfo=UTC)),
         (1893501000000, datetime(2030, 1, 1, 12, 30, tzinfo=UTC)),
+        (35, None),
+        (0, None),
+        (-1, None),
+        ({"min": 25, "max": 35}, None),
         (True, None),
         ("25-35 min", None),
         (None, None),
@@ -270,6 +318,89 @@ async def test_legacy_order_unique_id_migrates_to_scoped_status_entity(
     assert migrated is not None
     assert migrated.unique_id == f"{entry.entry_id}_{order_id}_status"
     assert migrated.translation_key == "order_status"
+
+
+async def test_inactive_legacy_order_is_migrated_and_restored(
+    hass: HomeAssistant,
+) -> None:
+    """Restore an existing final order entity after an upgrade and restart."""
+    order_id = "sanitized-purchase-001"
+    coordinator = mock_coordinator(
+        WoltCoordinatorData(
+            orders={
+                order_id: {
+                    "purchase_id": order_id,
+                    "status": {"value": "In progress"},
+                    "telemetry": {"order_status_type": "DELIVERED"},
+                }
+            },
+            active_order_ids=frozenset(),
+            details={},
+        )
+    )
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_NAME: "Sanitized Wolt"})
+    entry.runtime_data = WoltRuntimeData(Mock(spec=WoltApi), coordinator)
+    entry.add_to_hass(hass)
+    registry = er.async_get(hass)
+    legacy = registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"wolt_{order_id}",
+        config_entry=entry,
+    )
+    add_entities = Mock()
+
+    await async_setup_entry(hass, entry, add_entities)
+
+    migrated = registry.async_get(legacy.entity_id)
+    assert migrated is not None
+    assert migrated.unique_id == f"{entry.entry_id}_{order_id}_status"
+    entities = add_entities.call_args.args[0]
+    assert len(entities) == 2
+    status = next(
+        entity for entity in entities if isinstance(entity, WoltOrderStatusSensor)
+    )
+    assert status.available
+    assert status.native_value == "delivered"
+
+
+async def test_inactive_scoped_order_is_restored_after_restart(
+    hass: HomeAssistant,
+) -> None:
+    """Recreate an existing scoped entity when its order is already final."""
+    order_id = "sanitized-purchase-001"
+    coordinator = mock_coordinator(
+        WoltCoordinatorData(
+            orders={
+                order_id: {
+                    "purchase_id": order_id,
+                    "telemetry": {"order_status_type": "DELIVERED"},
+                }
+            },
+            active_order_ids=frozenset(),
+            details={},
+        )
+    )
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_NAME: "Sanitized Wolt"})
+    entry.runtime_data = WoltRuntimeData(Mock(spec=WoltApi), coordinator)
+    entry.add_to_hass(hass)
+    registry = er.async_get(hass)
+    registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{entry.entry_id}_{order_id}_status",
+        config_entry=entry,
+    )
+    add_entities = Mock()
+
+    await async_setup_entry(hass, entry, add_entities)
+
+    entities = add_entities.call_args.args[0]
+    assert len(entities) == 2
+    status = next(
+        entity for entity in entities if isinstance(entity, WoltOrderStatusSensor)
+    )
+    assert status.native_value == "delivered"
 
 
 async def test_legacy_entity_is_not_migrated_across_config_entries(


### PR DESCRIPTION
## Summary

Address the delayed immutable review blockers and privacy nonblockers from PR #29:

- reject small, zero, negative, range-like, and otherwise implausible numeric ETA values instead of interpreting them as Unix timestamps
- keep telemetry authoritative in both directions: final/non-active telemetry overrides stale active display text, while `IN_PROGRESS` accepts only non-final rich display detail
- restore and migrate existing inactive/final order entities after restart, without creating entities for every historical order
- restore already-scoped entities as well as legacy entities
- preserve cross-config-entry migration ownership
- use Home Assistant's documented list type for enum options
- remove order-ID suffixes from user-facing device names
- remove venue/order metadata from entity attributes

## Regression coverage

- duration-like numeric ETAs (`35`, `0`, `-1`, and `{min,max}` ranges)
- valid ISO and millisecond timestamps
- stale `In progress` display status with authoritative `DELIVERED` telemetry
- inactive legacy entity migration and final-state restoration
- inactive scoped entity restoration after restart
- cross-config-entry migration isolation
- user-facing order name and attribute privacy

## Verification

At exact head `d4972bea497e3f656f6f44b13c648730ac4bc748`:

- Ruff lint and format passed
- pytest: 87 passed
- `git diff --check` passed
- Hassfest: 1 integration, 0 invalid
- `detect-secrets`: 0 findings

Follow-up to #29.
