### PR TITLE
docs: adopt Wait for Wolt and clarify current scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to Wolt Order Tracker will be documented here.
+All notable changes to Wait for Wolt will be documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
@@ -37,6 +37,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   access or refresh tokens.
 - Order status entities use stable normalized enum values, config-entry-scoped
   unique IDs, and a shared per-purchase device.
+- The public display name is now **Wait for Wolt**, with clearer documentation
+  of the integration's current order, ETA, venue, and privacy boundaries.
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for helping improve Wolt Order Tracker. This is an unofficial Home Assistant integration built on Wolt's private consumer web API, so reliability, privacy, and conservative request behavior are core requirements.
+Thanks for helping improve Wait for Wolt. This is an unofficial Home Assistant integration built on Wolt's private consumer web API, so reliability, privacy, and conservative request behavior are core requirements.
 
 ## Before opening a change
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,35 @@
-# ha-wait-for-wolt
+# Wait for Wolt
 
-This custom component tracks your Wolt orders in Home Assistant. It polls the Wolt API using tokens that you obtain once from the web site and persists refreshed credentials in a Home Assistant config entry.
+**Wait for Wolt** is an unofficial Home Assistant custom integration for
+tracking active Wolt deliveries. It creates automation-friendly sensors for an
+order's normalized status and estimated arrival time, refreshes browser-derived
+Wolt credentials when needed, and can optionally monitor selected venues for
+availability and delivery estimates.
+
+The integration deliberately does not expose item lists, payment details,
+addresses, order identifiers, or raw Wolt responses as entity attributes. It is
+not affiliated with or endorsed by Wolt and relies on Wolt's private consumer
+web API, which may change without notice.
+
+## What it provides
+
+- A device for each active purchase, with a stable status sensor and timestamp
+  ETA sensor suitable for dashboards, notifications, and automations.
+- Automatic discovery of orders placed while Home Assistant is running.
+- Durable access-token refresh and Home Assistant reauthentication when saved
+  Wolt credentials stop working.
+- Optional venue sensors for open/closed status, delivery fees, and delivery
+  estimates when Wolt provides them.
+- Conservative shared polling and privacy-preserving diagnostics.
+
+Live courier maps, route points, spending history, and websocket updates are not
+part of the current release-ready feature set.
 
 ## Installation via HACS
 Requires Home Assistant 2026.7.0 or newer.
 
 1. Add this repository as a custom repository in [HACS](https://hacs.xyz/).
-2. Install **Wolt Order Tracker** and restart Home Assistant.
+2. Install **Wait for Wolt** and restart Home Assistant.
 
 ## Getting your tokens
 Tokens are required to authenticate with the Wolt API. The easiest way to

--- a/custom_components/wait_for_wolt/diagnostics.py
+++ b/custom_components/wait_for_wolt/diagnostics.py
@@ -1,4 +1,4 @@
-"""Privacy-preserving diagnostics for Wolt Order Tracker."""
+"""Privacy-preserving diagnostics for Wait for Wolt."""
 
 from __future__ import annotations
 

--- a/custom_components/wait_for_wolt/manifest.json
+++ b/custom_components/wait_for_wolt/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "wait_for_wolt",
-  "name": "Wolt Order Tracker",
+  "name": "Wait for Wolt",
   "codeowners": ["@selfish"],
   "config_flow": true,
   "documentation": "https://github.com/selfish/ha-wait-for-wolt",

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "Wolt Order Tracker",
+  "name": "Wait for Wolt",
   "content_in_root": false,
   "homeassistant": "2026.7.0",
   "render_readme": true

--- a/info.md
+++ b/info.md
@@ -1,6 +1,14 @@
-# Wolt Order Tracker
+# Wait for Wolt
 
-Track your Wolt deliveries in Home Assistant. You can configure the integration from the UI or provide an access token and refresh token in YAML. The analytics session ID is optional. The integration refreshes credentials only when Wolt rejects the access token and creates sensors for active orders. You can also monitor venues by adding their IDs to get open/closed status.
+Wait for Wolt is an unofficial Home Assistant integration for active Wolt
+deliveries. It creates stable status and estimated-arrival sensors for each
+active purchase, refreshes saved credentials when needed, and can optionally
+monitor selected venues for availability and delivery estimates. It does not
+expose order contents, payment details, addresses, or raw Wolt responses as
+entity attributes.
+
+Configure the integration from the Home Assistant UI using an access token and
+refresh token obtained from wolt.com. The analytics session ID is optional.
 Venue IDs correspond to the slug in the venue URL, for example `mententen` in
 `https://wolt.com/en/isr/tel-aviv/restaurant/mententen`. When configuring via the UI, place each ID on its own line.
 


### PR DESCRIPTION
## Summary

- adopt **Wait for Wolt** as the public display name while preserving the `wait_for_wolt` domain and repository identity
- explain the current active-order status/ETA and optional venue-monitoring behavior at the top of the README and HACS information page
- state the privacy boundary and clearly distinguish unreleased courier-map, route, spend, and websocket features
- align the manifest, HACS metadata, changelog, contributor guide, and diagnostics wording

## Verification

- `uv sync --frozen`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest` — 87 passed
- `git diff --check`

## Design intent

Preserve the stable technical identity (`wait_for_wolt`, repository slug, config entries, and entity namespace) while giving the integration a distinctive public name that does not imply official Wolt affiliation. Public copy leads with exactly what the current integration does and does not claim unreleased functionality.

Related to #31.
